### PR TITLE
Do not allow whitespace in VIRTUALENV_NAME

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -297,6 +297,11 @@ if [ -z "${VERSION_NAME}" ] || [ -z "${VIRTUALENV_NAME}" ]; then
   usage 1
 fi
 
+if [ "$VIRTUALENV_NAME" != "${VIRTUALENV_NAME%[[:space:]]*}" ]; then
+  echo "pyenv-virtualenv: no whitespace allowed in virtualenv name." 1>&2
+  exit 1
+fi
+
 # Set VERSION_NAME as default version in this script
 export PYENV_VERSION="${VERSION_NAME}"
 

--- a/test/virtualenv.bats
+++ b/test/virtualenv.bats
@@ -132,3 +132,21 @@ OUT
   unstub pyenv-exec
   unstub curl
 }
+
+@test "no whitespace allowed in virtualenv name" {
+  run pyenv-virtualenv "3.2.1" "foo bar"
+
+  assert_failure
+  assert_output <<OUT
+pyenv-virtualenv: no whitespace allowed in virtualenv name.
+OUT
+}
+
+@test "no tab allowed in virtualenv name" {
+  run pyenv-virtualenv "3.2.1" "foo	bar baz"
+
+  assert_failure
+  assert_output <<OUT
+pyenv-virtualenv: no whitespace allowed in virtualenv name.
+OUT
+}


### PR DESCRIPTION
While this could work in general, it fails in the end, because
whitespace is not allowed/supported in the shebang line with the
scripts in the created virtualenv.
