### PR TITLE
Unset PYENV_DEACTIVATE after deactivating into "system"

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -112,6 +112,7 @@ if [[ "$shell" != "fish" ]]; then
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name)" = "system" ]; then
       pyenv deactivate --no-error --verbose
+      unset PYENV_DEACTIVATE
       return 0
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix)" ]; then


### PR DESCRIPTION
With "pyenv global system" set, I couldn't re-activate a virtualenv after deactivating it, because the PYENV_DEACTIVATE was remaining set after deactivating the virtualenv.
