### PR TITLE
Initialise a virtualenv based off of .python-venv

### DIFF
--- a/bin/pyenv-deactivate
+++ b/bin/pyenv-deactivate
@@ -3,8 +3,6 @@
 # Summary: Deactivate virtual environment
 #
 # Usage: pyenv deactivate
-#
-# Deactivate a Python virtual environment.
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -42,11 +42,11 @@ while [ $# -gt 0 ]; do
 done
 
 no_shell=
-versions=("$@")
-if [ -z "${versions}" ]; then
+virtualenvs=("$@")
+if [ -z "${virtualenvs}" ]; then
   no_shell=1
   OLDIFS="$IFS"
-  IFS=: versions=($(pyenv-version-name))
+  IFS=: virtualenvs=($(pyenv-virtualenv-name))
   IFS="$OLDIFS"
 fi
 
@@ -56,14 +56,14 @@ if [ -z "${PYENV_VIRTUALENV_INIT}" ]; then
   no_shell=
 fi
 
-if [ "${#versions[@]}" -gt 1 ]; then
-  [ -n "$NOERROR" ] || echo "pyenv-virtualenv: cannot activate multiple versions at once: ${versions[@]}" 1>&2
+if [ "${#virtualenvs[@]}" -gt 1 ]; then
+  [ -n "$NOERROR" ] || echo "pyenv-virtualenv: cannot activate multiple virtualenvs at once: ${virtualenvs[@]}" 1>&2
   echo "false"
   exit 1
 fi
 
-if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
-  [ -n "$NOERROR" ] || echo "pyenv-virtualenv: version \`${versions}' is not a virtualenv" 1>&2
+if ! pyenv-virtualenv-prefix "${virtualenvs}" 1>/dev/null 2>&1; then
+  [ -n "$NOERROR" ] || echo "pyenv-virtualenv: version \`${virtualenvs}' is not a virtualenv" 1>&2
   echo "false"
   exit 1
 fi
@@ -93,11 +93,11 @@ if [ -f "$profile" ] && grep -q 'pyenv init -' "$profile" && ! grep -q 'pyenv vi
 fi
 
 if [ -n "$VERBOSE" ]; then
-  echo "pyenv-virtualenv: activate ${versions}" 1>&2
+  echo "pyenv-virtualenv: activate ${virtualenvs}" 1>&2
 fi
 
 if [ -z "$no_shell" ]; then
-  echo "pyenv shell \"${versions}\";"
+  echo "pyenv shell \"${virtualenvs}\";"
   # shell version set in pyenv-sh-activate should be unset
   # https://github.com/yyuu/pyenv-virtualenv/issues/61
   case "$shell" in
@@ -110,7 +110,7 @@ if [ -z "$no_shell" ]; then
   esac
 fi
 
-prefix="$(pyenv-prefix "${versions}")"
+prefix="$(pyenv-prefix "${virtualenvs}")"
 case "$shell" in
 fish )
   cat <<EOS

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -3,8 +3,6 @@
 # Summary: Deactivate virtual environment
 #
 # Usage: pyenv deactivate
-#
-# Deactivate a Python virtual environment.
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -7,7 +7,6 @@
 #        pyenv virtualenv --help
 #
 #   -f/--force       Install even if the version appears to be installed already
-#
 
 PYENV_VIRTUALENV_VERSION="20150119"
 

--- a/bin/pyenv-virtualenv-file
+++ b/bin/pyenv-virtualenv-file
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Summary: Detect the file that sets the current Python virtual environment
+#
+# Usage: pyenv virtualenv-file
+
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+find_local_virtualenv_file() {
+  local root="$1"
+  while [ -n "$root" ]; do
+    if [ -e "${root}/.python-venv" ]; then
+      echo "${root}/.python-venv"
+      exit
+    elif [ -e "${root}/.pyenv-venv" ]; then
+      echo "${root}/.pyenv-venv"
+      exit
+    fi
+    [ "${root}" = "${root%/*}" ] && break
+    root="${root%/*}"
+  done
+}
+
+find_local_virtualenv_file "$PYENV_DIR"
+[ "$PYENV_DIR" = "$PWD" ] || find_local_virtualenv_file "$PWD"
+
+exit 1

--- a/bin/pyenv-virtualenv-file-read
+++ b/bin/pyenv-virtualenv-file-read
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Usage: pyenv virtualenv-file-read <file>
+
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+VIRTUALENV_FILE="$1"
+
+if [ -e "$VIRTUALENV_FILE" ]; then
+  # Read the first non-whitespace word from the specified version file.
+  # Be careful not to load it whole in case there's something crazy in it.
+  IFS="${IFS}"$'\r'
+  words=( $(cut -b 1-1024 "$VIRTUALENV_FILE" | $(type -p gawk awk | head -1) '{ print($1) }') )
+  virtualenvs=("${words[@]}")
+
+  if [ -n "$virtualenvs" ]; then
+    IFS=":"
+    echo "${virtualenvs[*]}"
+    exit
+  fi
+fi
+
+exit 1

--- a/bin/pyenv-virtualenv-file-write
+++ b/bin/pyenv-virtualenv-file-write
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Usage: pyenv virtualenv-file-write <file> <venv-name>
+
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+PYENV_VIRTUALENV_FILE="$1"
+shift || true
+virtualenvs=("$@")
+
+if [ -z "$virtualenvs" ] || [ -z "$PYENV_VIRTUALENV_FILE" ]; then
+  pyenv-help --usage virtualenv-file-write >&2
+  exit 1
+fi
+
+# Make sure the specified virtual environment is created
+pyenv-virtualenv-prefix "${virtualenvs[@]}" >/dev/null
+
+# Write the virtual environment name out to disk.
+# Create an empty file. Using "rm" might cause a permission error.
+> "$PYENV_VIRTUALENV_FILE"
+for virtualenv in "${virtualenvs[@]}"; do
+  echo "$virtualenv" >> "$PYENV_VIRTUALENV_FILE"
+done

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
+#
 # Summary: Configure the shell environment for pyenv-virtualenv
+#
 # Usage: eval "$(pyenv virtualenv-init - [<shell>])"
 #
-# Automatically activates a Python virtualenv environment based on current
-# pyenv version.
-#
+# Automatically activates a Python virtualenv environment.
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -75,24 +75,28 @@ case "$shell" in
 fish )
   cat <<EOS
 function _pyenv_virtualenv_hook --on-event fish_prompt;
-  set -l PYENV_PREFIX (pyenv prefix 2>/dev/null; or true)
+  set -l virtualenv (pyenv virtualenv-name; or true)
+  set -l prefix (pyenv prefix "\$virtualenv" 2>/dev/null; or true)
+
   if [ -n "\$PYENV_ACTIVATE" ]
-    if [ "(pyenv version-name 2>/dev/null; or true)" = "system" ]
+    if [ -n "\$virtualenv" ]
+      if [ "\$PYENV_ACTIVATE" != "\$prefix" ]
+        if pyenv deactivate --no-error --verbose
+          pyenv activate --no-error --verbose; or set -e PYENV_DEACTIVATE
+        else
+          pyenv activate --no-error --verbose
+        end
+      end
+    else
       pyenv deactivate --no-error --verbose
       set -e PYENV_DEACTIVATE
       return 0
     end
-    if [ "\$PYENV_ACTIVATE" != "\$PYENV_PREFIX" ]
-      if pyenv deactivate --no-error --verbose
-        set -e PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose; or set -e PYENV_DEACTIVATE
-      else
+  else
+    if [ -z "\$VIRTUAL_ENV" ]
+      if [ -n "\$virtualenv" ]; and [ "\$PYENV_DEACTIVATE" != "\$prefix" ]
         pyenv activate --no-error --verbose
       end
-    end
-  else
-    if [ -z "\$VIRTUAL_ENV" ]; and [ "\$PYENV_DEACTIVATE" != "\$PYENV_PREFIX" ]
-      pyenv activate --no-error --verbose
     end
   end
 end
@@ -112,23 +116,28 @@ esac
 
 if [[ "$shell" != "fish" ]]; then
   cat <<EOS
+  virtualenv="\$(pyenv virtualenv-name || true)"
+  prefix="\$(pyenv prefix "\$virtualenv" 2>/dev/null || true)"
+
   if [ -n "\$PYENV_ACTIVATE" ]; then
-    if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
+    if [ -n "\$virtualenv" ]; then
+      if [ "\$PYENV_ACTIVATE" != "\$prefix" ]; then
+        if pyenv deactivate --no-error --verbose; then
+          pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
+        else
+          pyenv activate --no-error --verbose
+        fi
+      fi
+    else
       pyenv deactivate --no-error --verbose
       unset PYENV_DEACTIVATE
       return 0
     fi
-    if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      if pyenv deactivate --no-error --verbose; then
-        unset PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
-      else
+  else
+    if [ -z "\$VIRTUAL_ENV" ]; then
+      if [ -n "\$virtualenv" ] && [ "\$PYENV_DEACTIVATE" != "\$prefix" ]; then
         pyenv activate --no-error --verbose
       fi
-    fi
-  else
-    if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose
     fi
   fi
 };

--- a/bin/pyenv-virtualenv-name
+++ b/bin/pyenv-virtualenv-name
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Summary: Show the current Python virtual environment
+#
+# Usage: pyenv virtualenv-name
+
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+if [ -z "$PYENV_VIRTUALENV" ]; then
+  PYENV_VIRTUALENV_FILE="$(pyenv-virtualenv-file)"
+  PYENV_VIRTUALENV="$(pyenv-virtualenv-file-read "$PYENV_VIRTUALENV_FILE" || true)"
+fi
+
+if [ -z "$PYENV_VIRTUALENV" ]; then
+  exit 1
+fi
+
+virtualenv_exists() {
+  local virtualenv="$1"
+  PREFIX="${PYENV_ROOT}/versions/${virtualenv}"
+  [ -f "${PREFIX}/bin/activate" ] && [ ! -e "${PREFIX}/bin/conda" ]
+}
+
+virtualenvs=()
+OLDIFS="$IFS"
+{ IFS=:
+  for virtualenv in ${PYENV_VIRTUALENV}; do
+    if virtualenv_exists "$virtualenv"; then
+      virtualenvs=("${virtualenvs[@]}" "${virtualenv}")
+    else
+      echo "pyenv-virtualenv: version \`$virtualenv' is not a virtualenv" >&2
+      exit 1
+    fi
+  done
+}
+IFS="$OLDIFS"
+
+OLDIFS="$IFS"
+{ IFS=:
+  echo "${virtualenvs[*]}"
+}
+IFS="$OLDIFS"

--- a/bin/pyenv-virtualenv-origin
+++ b/bin/pyenv-virtualenv-origin
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Summary: Explain how the current Python virtual environment is set
+#
+# Usage: pyenv virtualenv-origin
+
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+if [ -n "$PYENV_VIRTUALENV" ]; then
+  echo "PYENV_VIRTUALENV environment variable"
+else
+  pyenv-virtualenv-file
+fi

--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Summary: Display real_prefix for a Python virtualenv version
-# Usage: pyenv virtualenv-prefix [<virtualenv>]
+# Summary: Display real_prefix for a Python virtualenv version.
 #
+# Usage: pyenv virtualenv-prefix [<virtualenv>]
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -12,42 +12,42 @@ if [ -z "$PYENV_ROOT" ]; then
 fi
 
 if [ -n "$1" ]; then
-  versions=($@)
+  virtualenvs=($@)
   IFS=: PYENV_VERSION="${versions[*]}"
   export PYENV_VERSION
 else
-  IFS=: versions=($(pyenv-version-name))
+  IFS=: virtualenvs=($(pyenv-virtualenv-name))
 fi
 
 real_prefix() { # virtualenv
-  local version="$1"
-  PYENV_VERSION="${version}" pyenv-exec python -c 'import sys;print(sys.real_prefix)' 2>/dev/null
+  local virtualenv="$1"
+  PYENV_VERSION="${virtualenv}" pyenv-exec python -c 'import sys;print(sys.real_prefix)' 2>/dev/null
 }
 
 base_prefix() { # pyvenv
   # FIXME: non-pyvenv versions also have sys.base_prefix
-  local version="$1"
-  PYENV_VERSION="${version}" pyenv-exec python -c 'import sys;print(sys.base_prefix)' 2>/dev/null
+  local virtualenv="$1"
+  PYENV_VERSION="${virtualenv}" pyenv-exec python -c 'import sys;print(sys.base_prefix)' 2>/dev/null
 }
 
 VIRTUALENV_PREFIX_PATHS=()
-for version in "${versions[@]}"; do
-  if [ "$version" = "system" ]; then
-    echo "pyenv-virtualenv: version \`${version}' is not a virtualenv" 1>&2
+for virtualenv in "${virtualenvs[@]}"; do
+  if [ "$virtualenv" = "system" ]; then
+    echo "pyenv-virtualenv: version \`${virtualenv}' is not a virtualenv" 1>&2
     exit 1
   fi
-  PREFIX="$(pyenv-prefix "${version}")"
+  PREFIX="$(pyenv-prefix "${virtualenv}")"
   if [ -f "${PREFIX}/bin/activate" ]; then
     # Anaconda has `activate` script nevertheless it is not a virtual environment (#65)
     if [ -f "${PREFIX}/bin/conda" ]; then
-      echo "pyenv-virtualenv: version \`${version}' is an anaconda/miniconda" 1>&2
+      echo "pyenv-virtualenv: version \`${virtualenv}' is an anaconda/miniconda" 1>&2
       exit 1
     else
-      VIRTUALENV_PREFIX_PATH="$(real_prefix "${version}" || base_prefix "${version}" || true)"
+      VIRTUALENV_PREFIX_PATH="$(real_prefix "${virtualenv}" || base_prefix "${virtualenv}" || true)"
       VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "$VIRTUALENV_PREFIX_PATH")
     fi
   else
-    echo "pyenv-virtualenv: version \`${version}' is not a virtualenv" 1>&2
+    echo "pyenv-virtualenv: version \`${virtualenv}' is not a virtualenv" 1>&2
     exit 1
   fi
 done

--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -3,7 +3,6 @@
 # Summary: List all Python virtualenvs found in `$PYENV_ROOT/versions/*'.
 #
 # Usage: pyenv virtualenvs [--bare]
-#
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -10,13 +10,13 @@ setup() {
 @test "activate virtualenv from current version" {
   export PYENV_VIRTUALENV_INIT=1
 
-  stub pyenv-version-name "echo venv"
+  stub pyenv-virtualenv-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
 
@@ -31,13 +31,13 @@ EOS
 @test "activate virtualenv from current version (verbose)" {
   export PYENV_VIRTUALENV_INIT=1
 
-  stub pyenv-version-name "echo venv"
+  stub pyenv-virtualenv-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate --verbose
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
 
@@ -53,13 +53,13 @@ EOS
 @test "activate virtualenv from current version (without pyenv-virtualenv-init)" {
   export PYENV_VIRTUALENV_INIT=
 
-  stub pyenv-version-name "echo venv"
+  stub pyenv-virtualenv-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
 
@@ -76,13 +76,13 @@ EOS
 @test "activate virtualenv from current version (fish)" {
   export PYENV_VIRTUALENV_INIT=1
 
-  stub pyenv-version-name "echo venv"
+  stub pyenv-virtualenv-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
 
@@ -97,13 +97,13 @@ EOS
 @test "activate virtualenv from current version (fish) (without pyenv-virtualenv-init)" {
   export PYENV_VIRTUALENV_INIT=
 
-  stub pyenv-version-name "echo venv"
+  stub pyenv-virtualenv-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
 
@@ -242,7 +242,7 @@ EOS
 
   assert_failure
   assert_output <<EOS
-pyenv-virtualenv: cannot activate multiple versions at once: venv venv27
+pyenv-virtualenv: cannot activate multiple virtualenvs at once: venv venv27
 false
 EOS
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -31,23 +31,28 @@ load test_helper
   assert_output <<EOS
 export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
+  virtualenv="\$(pyenv virtualenv-name || true)"
+  prefix="\$(pyenv prefix "\$virtualenv" 2>/dev/null || true)"
+
   if [ -n "\$PYENV_ACTIVATE" ]; then
-    if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
+    if [ -n "\$virtualenv" ]; then
+      if [ "\$PYENV_ACTIVATE" != "\$prefix" ]; then
+        if pyenv deactivate --no-error --verbose; then
+          pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
+        else
+          pyenv activate --no-error --verbose
+        fi
+      fi
+    else
       pyenv deactivate --no-error --verbose
       unset PYENV_DEACTIVATE
       return 0
     fi
-    if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      if pyenv deactivate --no-error --verbose; then
-        unset PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
-      else
+  else
+    if [ -z "\$VIRTUAL_ENV" ]; then
+      if [ -n "\$virtualenv" ] && [ "\$PYENV_DEACTIVATE" != "\$prefix" ]; then
         pyenv activate --no-error --verbose
       fi
-    fi
-  else
-    if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose
     fi
   fi
 };
@@ -63,24 +68,28 @@ EOS
   assert_output <<EOS
 setenv PYENV_VIRTUALENV_INIT 1;
 function _pyenv_virtualenv_hook --on-event fish_prompt;
-  set -l PYENV_PREFIX (pyenv prefix 2>/dev/null; or true)
+  set -l virtualenv (pyenv virtualenv-name; or true)
+  set -l prefix (pyenv prefix "\$virtualenv" 2>/dev/null; or true)
+
   if [ -n "\$PYENV_ACTIVATE" ]
-    if [ "(pyenv version-name 2>/dev/null; or true)" = "system" ]
+    if [ -n "\$virtualenv" ]
+      if [ "\$PYENV_ACTIVATE" != "\$prefix" ]
+        if pyenv deactivate --no-error --verbose
+          pyenv activate --no-error --verbose; or set -e PYENV_DEACTIVATE
+        else
+          pyenv activate --no-error --verbose
+        end
+      end
+    else
       pyenv deactivate --no-error --verbose
       set -e PYENV_DEACTIVATE
       return 0
     end
-    if [ "\$PYENV_ACTIVATE" != "\$PYENV_PREFIX" ]
-      if pyenv deactivate --no-error --verbose
-        set -e PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose; or set -e PYENV_DEACTIVATE
-      else
+  else
+    if [ -z "\$VIRTUAL_ENV" ]
+      if [ -n "\$virtualenv" ]; and [ "\$PYENV_DEACTIVATE" != "\$prefix" ]
         pyenv activate --no-error --verbose
       end
-    end
-  else
-    if [ -z "\$VIRTUAL_ENV" ]; and [ "\$PYENV_DEACTIVATE" != "\$PYENV_PREFIX" ]
-      pyenv activate --no-error --verbose
     end
   end
 end
@@ -93,23 +102,28 @@ EOS
   assert_output <<EOS
 export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
+  virtualenv="\$(pyenv virtualenv-name || true)"
+  prefix="\$(pyenv prefix "\$virtualenv" 2>/dev/null || true)"
+
   if [ -n "\$PYENV_ACTIVATE" ]; then
-    if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
+    if [ -n "\$virtualenv" ]; then
+      if [ "\$PYENV_ACTIVATE" != "\$prefix" ]; then
+        if pyenv deactivate --no-error --verbose; then
+          pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
+        else
+          pyenv activate --no-error --verbose
+        fi
+      fi
+    else
       pyenv deactivate --no-error --verbose
       unset PYENV_DEACTIVATE
       return 0
     fi
-    if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      if pyenv deactivate --no-error --verbose; then
-        unset PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
-      else
+  else
+    if [ -z "\$VIRTUAL_ENV" ]; then
+      if [ -n "\$virtualenv" ] && [ "\$PYENV_DEACTIVATE" != "\$prefix" ]; then
         pyenv activate --no-error --verbose
       fi
-    fi
-  else
-    if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose
     fi
   fi
 };

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -5,8 +5,19 @@ PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
 PATH="$TMP/bin:$PATH"
 export PATH
 
+if enable -f "${BATS_TEST_DIRNAME}"/../libexec/pyenv-realpath.dylib realpath 2>/dev/null; then
+  PYENV_VIRTUALENV_TEST_DIR="$(realpath "$BATS_TMPDIR")/pyenv-virtualenv"
+else
+  if [ -n "$PYENV_NATIVE_EXT" ]; then
+    echo "pyenv: failed to load \`realpath' builtin" >&2
+    exit 1
+  fi
+  PYENV_VIRTUALENV_TEST_DIR="${BATS_TMPDIR}/pyenv-virtualenv"
+fi
+
 teardown() {
   rm -fr "$TMP"/*
+  rm -fr "$PYENV_VIRTUALENV_TEST_DIR"
 }
 
 stub() {

--- a/test/virtualenv-file-read.bats
+++ b/test/virtualenv-file-read.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  mkdir -p "${PYENV_VIRTUALENV_TEST_DIR}/myproject"
+  cd "${PYENV_VIRTUALENV_TEST_DIR}/myproject"
+}
+
+@test "fails without arguments" {
+  run pyenv-virtualenv-file-read
+  assert_failure ""
+}
+
+@test "fails for invalid file" {
+  run pyenv-virtualenv-file-read "non-existent"
+  assert_failure ""
+}
+
+@test "fails for blank file" {
+  echo > my-venv
+  run pyenv-virtualenv-file-read my-venv
+  assert_failure ""
+}
+
+@test "reads simple venv file" {
+  cat > my-venv <<<"foo"
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo"
+}
+
+@test "ignores leading spaces" {
+  cat > my-venv <<<"  foo"
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo"
+}
+
+@test "reads only the first word from file" {
+  cat > my-venv <<<"foo bar baz"
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo"
+}
+
+@test "loads *not* only the first line in file" {
+  cat > my-venv <<IN
+foo bar
+baz qux
+IN
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo:baz"
+}
+
+@test "ignores leading blank lines" {
+  cat > my-venv <<IN
+foo
+IN
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo"
+}
+
+@test "handles the file with no trailing newline" {
+  echo -n "foo" > my-venv
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo"
+}
+
+@test "ignores carriage returns" {
+  cat > my-venv <<< $'foo\r'
+  run pyenv-virtualenv-file-read my-venv
+  assert_success "foo"
+}

--- a/test/virtualenv-file-write.bats
+++ b/test/virtualenv-file-write.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export PYENV_ROOT="${TMP}/pyenv"
+
+  mkdir -p "$PYENV_VIRTUALENV_TEST_DIR"
+  cd "$PYENV_VIRTUALENV_TEST_DIR"
+}
+
+create_virtualenv() {
+  mkdir -p "${PYENV_ROOT}/versions/$1/bin"
+  touch "${PYENV_ROOT}/versions/$1/bin/activate"
+}
+
+@test "invocation without 2 arguments prints usage" {
+  stub pyenv-help "echo \"Usage: pyenv virtualenv-file-write <file> <venv-name>\""
+  run pyenv-virtualenv-file-write
+  unstub pyenv-help
+  assert_failure "Usage: pyenv virtualenv-file-write <file> <venv-name>"
+
+  run pyenv-virtualenv-file-write "one" ""
+  assert_failure
+}
+
+@test "setting nonexistent virtualenv fails" {
+  assert [ ! -e ".python-venv" ]
+
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  run pyenv-virtualenv-file-write ".python-venv" "venv"
+  unstub pyenv-prefix
+
+  assert_failure "pyenv-virtualenv: version \`venv' is not a virtualenv"
+  assert [ ! -e ".python-venv" ]
+}
+
+@test "writes value to arbitrary file" {
+  create_virtualenv "venv"
+
+  assert [ ! -e "my-venv" ]
+
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  run pyenv-virtualenv-file-write "${PWD}/my-venv" "venv"
+  unstub pyenv-prefix
+
+  assert_success ""
+  assert [ "$(cat my-venv)" = "venv" ]
+}

--- a/test/virtualenv-file.bats
+++ b/test/virtualenv-file.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  mkdir -p "$PYENV_VIRTUALENV_TEST_DIR"
+  cd "$PYENV_VIRTUALENV_TEST_DIR"
+}
+
+create_file() {
+  mkdir -p "$(dirname "$1")"
+  touch "$1"
+}
+
+@test "in current directory" {
+  create_file ".python-venv"
+  run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/.python-venv"
+}
+
+@test "alternate file in current directory" {
+  create_file ".pyenv-venv"
+  run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/.pyenv-venv"
+}
+
+@test ".python-venv has precedence over alternate file" {
+  create_file ".python-venv"
+  create_file ".pyenv-venv"
+  run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/.python-venv"
+}
+
+@test "in parent directory" {
+  create_file ".python-venv"
+  mkdir -p project
+  cd project
+  run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/.python-venv"
+}
+
+@test "topmost file has precedence" {
+  create_file ".python-venv"
+  create_file "project/.python-venv"
+  cd project
+  run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/project/.python-venv"
+}
+
+@test "alternate file has precedence if higher" {
+  create_file ".python-venv"
+  create_file "project/.pyenv-venv"
+  cd project
+  run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/project/.pyenv-venv"
+}
+
+@test "PYENV_DIR has precedence over PWD" {
+  create_file "widget/.python-venv"
+  create_file "project/.python-venv"
+  cd project
+  PYENV_DIR="${PYENV_VIRTUALENV_TEST_DIR}/widget" run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/widget/.python-venv"
+}
+
+@test "PWD is searched if PYENV_DIR yields no results" {
+  mkdir -p "widget/blank"
+  create_file "project/.python-venv"
+  cd project
+  PYENV_DIR="${PYENV_VIRTUALENV_TEST_DIR}/widget/blank" run pyenv-virtualenv-file
+  assert_success "${PYENV_VIRTUALENV_TEST_DIR}/project/.python-venv"
+}

--- a/test/virtualenv-name.bats
+++ b/test/virtualenv-name.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export PYENV_ROOT="${TMP}/pyenv"
+
+  mkdir -p "${PYENV_VIRTUALENV_TEST_DIR}/myproject"
+  cd "${PYENV_VIRTUALENV_TEST_DIR}/myproject"
+}
+
+create_virtualenv() {
+  mkdir -p "${PYENV_ROOT}/versions/$1/bin"
+  touch "${PYENV_ROOT}/versions/$1/bin/activate"
+}
+
+@test "no virtualenv selected" {
+  assert [ ! -d "${PYENV_ROOT}/versions" ]
+  run pyenv-virtualenv-name
+  assert_failure ""
+}
+
+@test "PYENV_VIRTUALENV has precedence over local" {
+  create_virtualenv "foo"
+  create_virtualenv "bar"
+
+  cat > ".python-venv" <<<"foo"
+  run pyenv-virtualenv-name
+  assert_success "foo"
+
+  PYENV_VIRTUALENV=bar run pyenv-virtualenv-name
+  assert_success "bar"
+}
+
+@test "should fail if the virtualenv is the system" {
+  PYENV_VIRTUALENV=system run pyenv-virtualenv-name
+  assert_failure "pyenv-virtualenv: version \`system' is not a virtualenv"
+}
+
+@test "missing virtualenv" {
+  PYENV_VIRTUALENV=foo run pyenv-virtualenv-name
+
+  assert_failure "pyenv-virtualenv: version \`foo' is not a virtualenv"
+}

--- a/test/virtualenv-origin.bats
+++ b/test/virtualenv-origin.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  mkdir -p "$PYENV_VIRTUALENV_TEST_DIR"
+  cd "$PYENV_VIRTUALENV_TEST_DIR"
+}
+
+@test "detects PYENV_VIRTUALENV" {
+  PYENV_VIRTUALENV=1 run pyenv-virtualenv-origin
+  assert_success "PYENV_VIRTUALENV environment variable"
+}
+
+@test "detects local file" {
+  touch .python-venv
+  run pyenv-virtualenv-origin
+  assert_success "${PWD}/.python-venv"
+}
+
+@test "detects alternate file" {
+  touch .pyenv-venv
+  run pyenv-virtualenv-origin
+  assert_success "${PWD}/.pyenv-venv"
+}

--- a/test/virtualenv-prefix.bats
+++ b/test/virtualenv-prefix.bats
@@ -16,14 +16,14 @@ remove_virtualenv() {
 }
 
 @test "display prefix with using sys.real_prefix" {
-  stub pyenv-version-name "echo venv27"
+  stub pyenv-virtualenv-name "echo venv27"
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-exec "echo \"${PYENV_ROOT}/versions/2.7.6\""
   create_virtualenv "venv27"
 
   PYENV_VERSION="venv27" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-prefix
   unstub pyenv-exec
   remove_virtualenv "venv27"
@@ -35,7 +35,7 @@ OUT
 }
 
 @test "display prefixes with using sys.real_prefix" {
-  stub pyenv-version-name "echo venv27:venv32"
+  stub pyenv-virtualenv-name "echo venv27:venv32"
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\"" \
                     "venv32 : echo \"${PYENV_ROOT}/versions/venv32\""
   stub pyenv-exec "echo \"${PYENV_ROOT}/versions/2.7.6\"" \
@@ -45,7 +45,7 @@ OUT
 
   PYENV_VERSION="venv27:venv32" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-prefix
   unstub pyenv-exec
   remove_virtualenv "venv27"
@@ -58,7 +58,7 @@ OUT
 }
 
 @test "display prefix with using sys.base_prefix" {
-  stub pyenv-version-name "echo venv33"
+  stub pyenv-virtualenv-name "echo venv33"
   stub pyenv-prefix "venv33 : echo \"${PYENV_ROOT}/versions/venv33\""
   stub pyenv-exec "false" \
                   "echo \"${PYENV_ROOT}/versions/3.3.3\""
@@ -66,7 +66,7 @@ OUT
 
   PYENV_VERSION="venv33" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-prefix
   unstub pyenv-exec
   remove_virtualenv "venv33"
@@ -78,7 +78,7 @@ OUT
 }
 
 @test "display prefixes with using sys.base_prefix" {
-  stub pyenv-version-name "echo venv33:venv34"
+  stub pyenv-virtualenv-name "echo venv33:venv34"
   stub pyenv-prefix "venv33 : echo \"${PYENV_ROOT}/versions/venv33\"" \
                     "venv34 : echo \"${PYENV_ROOT}/versions/venv34\""
   stub pyenv-exec "false" \
@@ -90,7 +90,7 @@ OUT
 
   PYENV_VERSION="venv33:venv34" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-prefix
   unstub pyenv-exec
   remove_virtualenv "venv33"
@@ -103,11 +103,11 @@ OUT
 }
 
 @test "should fail if the version is the system" {
-  stub pyenv-version-name "echo system"
+  stub pyenv-virtualenv-name "echo system"
 
   PYENV_VERSION="system" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
 
   assert_failure
   assert_output <<OUT
@@ -116,13 +116,13 @@ OUT
 }
 
 @test "should fail if the version is not a virtualenv" {
-  stub pyenv-version-name "echo 3.4.0"
+  stub pyenv-virtualenv-name "echo 3.4.0"
   stub pyenv-prefix "3.4.0 : echo \"${PYENV_ROOT}/versions/3.4.0\""
   mkdir -p "${PYENV_ROOT}/versions/3.4.0"
 
   PYENV_VERSION="3.4.0" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-prefix
   rmdir "${PYENV_ROOT}/versions/3.4.0"
 
@@ -132,8 +132,28 @@ pyenv-virtualenv: version \`3.4.0' is not a virtualenv
 OUT
 }
 
+@test "should fail if the version is not an anaconda/miniconda" {
+  stub pyenv-virtualenv-name "echo foo"
+  stub pyenv-prefix "foo : echo \"${PYENV_ROOT}/versions/foo\""
+  mkdir -p "${PYENV_ROOT}/versions/foo"
+  mkdir -p "${PYENV_ROOT}/versions/foo/bin"
+  touch "${PYENV_ROOT}/versions/foo/bin/activate"
+  touch "${PYENV_ROOT}/versions/foo/bin/conda"
+
+  PYENV_VERSION="foo" run pyenv-virtualenv-prefix
+
+  unstub pyenv-virtualenv-name
+  unstub pyenv-prefix
+  rm -r "${PYENV_ROOT}/versions/foo"
+
+  assert_failure
+  assert_output <<OUT
+pyenv-virtualenv: version \`foo' is an anaconda/miniconda
+OUT
+}
+
 @test "should fail if one of the versions is not a virtualenv" {
-  stub pyenv-version-name "echo venv33:3.4.0"
+  stub pyenv-virtualenv-name "echo venv33:3.4.0"
   stub pyenv-prefix "venv33 : echo \"${PYENV_ROOT}/versions/venv33\"" \
                     "3.4.0 : echo \"${PYENV_ROOT}/versions/3.4.0\""
   stub pyenv-exec "false" \
@@ -143,7 +163,7 @@ OUT
 
   PYENV_VERSION="venv33:3.4.0" run pyenv-virtualenv-prefix
 
-  unstub pyenv-version-name
+  unstub pyenv-virtualenv-name
   unstub pyenv-prefix
   unstub pyenv-exec
   remove_virtualenv "venv33"
@@ -154,5 +174,3 @@ OUT
 pyenv-virtualenv: version \`3.4.0' is not a virtualenv
 OUT
 }
-
-


### PR DESCRIPTION
I've found that having one local file that handles either the python version or the virtualenv name doesn't really work with my workflow.

The python version is stored in the repo so every developer is using the same version, but this doesn't play well with then automatically initialising the virtualenv.

I've changed `bin/pyenv-virtualenv-init` to initialise the virtualenv named in a `.python-venv` file.

Not sure if it's relevant for everyone, but I thought I'd share my changes and and see what other people think.