### PR TITLE
Ignore failure of pyenv activate

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -92,7 +92,7 @@ function _pyenv_virtualenv_hook --on-event fish_prompt;
     end
   else
     if [ -z "\$VIRTUAL_ENV" ]; and [ "\$PYENV_DEACTIVATE" != "\$PYENV_PREFIX" ]
-      pyenv activate --no-error --verbose
+      pyenv activate --no-error --verbose; or true
     end
   end
 end
@@ -128,7 +128,7 @@ if [[ "$shell" != "fish" ]]; then
     fi
   else
     if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose
+      pyenv activate --no-error --verbose || true
     fi
   fi
 };

--- a/test/init.bats
+++ b/test/init.bats
@@ -47,7 +47,7 @@ _pyenv_virtualenv_hook() {
     fi
   else
     if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose
+      pyenv activate --no-error --verbose || true
     fi
   fi
 };
@@ -80,7 +80,7 @@ function _pyenv_virtualenv_hook --on-event fish_prompt;
     end
   else
     if [ -z "\$VIRTUAL_ENV" ]; and [ "\$PYENV_DEACTIVATE" != "\$PYENV_PREFIX" ]
-      pyenv activate --no-error --verbose
+      pyenv activate --no-error --verbose; or true
     end
   end
 end
@@ -109,7 +109,7 @@ _pyenv_virtualenv_hook() {
     fi
   else
     if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose
+      pyenv activate --no-error --verbose || true
     fi
   fi
 };


### PR DESCRIPTION
When the current pyenv environment is not a virtualenv, this line
exits with a return code of 1. This is annoying for those of us
who report the last return code in our own PROMPT_COMMAND, so
ignore the output of `pyenv activate` if we're not currently using
a virtualenv.