### PR TITLE
Use `typeset -g` with `precmd_functions`

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -144,7 +144,7 @@ EOS
     ;;
   zsh )
     cat <<EOS
-typeset -a precmd_functions
+typeset -g -a precmd_functions
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
   precmd_functions+=_pyenv_virtualenv_hook;
 fi

--- a/test/init.bats
+++ b/test/init.bats
@@ -113,7 +113,7 @@ _pyenv_virtualenv_hook() {
     fi
   fi
 };
-typeset -a precmd_functions
+typeset -g -a precmd_functions
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
   precmd_functions+=_pyenv_virtualenv_hook;
 fi


### PR DESCRIPTION
This makes it possible to use `eval "$(pyenv virtualenv-init -)"` from a
function.