### PR TITLE
Stop overriding existing precmd_functions in zsh.

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -144,7 +144,9 @@ EOS
     ;;
   zsh )
     cat <<EOS
-typeset -a precmd_functions
+if [[ -z \$precmd_functions ]]; then
+  typeset -a precmd_functions
+fi
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
   precmd_functions+=_pyenv_virtualenv_hook;
 fi

--- a/test/init.bats
+++ b/test/init.bats
@@ -113,7 +113,9 @@ _pyenv_virtualenv_hook() {
     fi
   fi
 };
-typeset -a precmd_functions
+if [[ -z $precmd_functions ]]; then
+  typeset -a precmd_functions
+fi
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
   precmd_functions+=_pyenv_virtualenv_hook;
 fi


### PR DESCRIPTION
Plugins for zsh like [prezto](https://github.com/sorin-ionescu/prezto) define a few of `precmd_functions`. When I was customizing it so it could invoke `eval "$(pyenv virtualenv-init -)"` I've encountered a problem: it turned out that some parts of the prompt disappeared. It turned out, that the reason is [this line](https://github.com/yyuu/pyenv-virtualenv/blob/master/bin/pyenv-virtualenv-init#L147). So I've added a conditional, so 3rd party applications weren't affected by this line.