### PR TITLE
activate: do not display note if initialized already

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -69,26 +69,10 @@ if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
 fi
 
 shell="${PYENV_SHELL:-${SHELL##*/}}"
-case "$shell" in
-bash )
-  profile="$HOME/.bash_profile"
-  ;;
-zsh )
-  profile="$HOME/.zshrc"
-  ;;
-ksh )
-  profile="$HOME/.profile"
-  ;;
-fish )
-  profile="$HOME/.config/fish/config.fish"
-  ;;
-* )
-  profile="$HOME/.profile"
-  ;;
-esac
 
-# Display setup instruction if 'pyenv virtualenv-init -' is not found in "$profile"
-if [ -f "$profile" ] && grep -q 'pyenv init -' "$profile" && ! grep -q 'pyenv virtualenv-init -' "$profile"; then
+# Display setup instruction, if pyenv-virtualenv has not been initialized.
+# if 'pyenv virtualenv-init -' is not found in "$profile"
+if [ -z "$PYENV_VIRTUALENV_INIT" ]; then
   pyenv-virtualenv-init >&2 || true
 fi
 

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -68,7 +68,7 @@ if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
   exit 1
 fi
 
-shell="$(basename "${PYENV_SHELL:-$SHELL}")"
+shell="${PYENV_SHELL:-${SHELL##*/}}"
 case "$shell" in
 bash )
   profile="$HOME/.bash_profile"

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -18,7 +18,7 @@ do
   fi
 done
 
-shell="$1"
+shell="${1:-$PYENV_SHELL}"
 if [ -z "$shell" ]; then
   shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
   shell="${shell##-}"

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -65,6 +65,11 @@ EOS
 
   assert_success
   assert_output <<EOS
+# Load pyenv-virtualenv automatically by adding
+# the following to ~/.bash_profile:
+
+eval "\$(pyenv virtualenv-init -)"
+
 pyenv shell "venv";
 export PYENV_ACTIVATE_SHELL=1;
 unset PYENV_DEACTIVATE;
@@ -109,6 +114,11 @@ EOS
 
   assert_success
   assert_output <<EOS
+# Load pyenv-virtualenv automatically by adding
+# the following to ~/.config/fish/config.fish:
+
+status --is-interactive; and . (pyenv virtualenv-init -|psub)
+
 pyenv shell "venv";
 setenv PYENV_ACTIVATE_SHELL 1;
 set -e PYENV_DEACTIVATE;
@@ -151,6 +161,11 @@ EOS
 
   assert_success
   assert_output <<EOS
+# Load pyenv-virtualenv automatically by adding
+# the following to ~/.bash_profile:
+
+eval "\$(pyenv virtualenv-init -)"
+
 pyenv shell "venv27";
 export PYENV_ACTIVATE_SHELL=1;
 unset PYENV_DEACTIVATE;
@@ -193,6 +208,11 @@ EOS
 
   assert_success
   assert_output <<EOS
+# Load pyenv-virtualenv automatically by adding
+# the following to ~/.config/fish/config.fish:
+
+status --is-interactive; and . (pyenv virtualenv-init -|psub)
+
 pyenv shell "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
 set -e PYENV_DEACTIVATE;

--- a/test/init.bats
+++ b/test/init.bats
@@ -3,6 +3,7 @@
 load test_helper
 
 @test "detect parent shell" {
+  unset PYENV_SHELL
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   SHELL=/bin/false run pyenv-virtualenv-init -
   assert_success


### PR DESCRIPTION
This fixes displaying the note, in case "init" has been run manually
and/or the init is not in the expected place.

It removes the unnecessary calls to "grep".

pyenv-virtualenv-init will look at `$PYENV_SHELL` now, too.

Tests have been adjusted/fixed.