### PR TITLE
init: fix shell detection when invoked from a script

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -20,10 +20,11 @@ done
 
 shell="${1:-$PYENV_SHELL}"
 if [ -z "$shell" ]; then
-  shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
+  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
   shell="${shell##-}"
   shell="${shell%% *}"
-  shell="$(basename "${shell:-$SHELL}")"
+  shell="${shell:-$SHELL}"
+  shell="${shell##*/}"
 fi
 
 if [ -z "$print" ]; then

--- a/test/init.bats
+++ b/test/init.bats
@@ -4,8 +4,25 @@ load test_helper
 
 @test "detect parent shell" {
   unset PYENV_SHELL
-  root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   SHELL=/bin/false run pyenv-virtualenv-init -
+  assert_success
+  assert_output_contains '  PROMPT_COMMAND="_pyenv_virtualenv_hook;$PROMPT_COMMAND";'
+}
+
+@test "detect parent shell from script (sh)" {
+  unset PYENV_SHELL
+  printf '#!/bin/sh\necho "$(pyenv-virtualenv-init -)"' > ${BATS_TEST_DIRNAME}/script.sh
+  chmod +x ${BATS_TEST_DIRNAME}/script.sh
+  run ${BATS_TEST_DIRNAME}/script.sh
+  assert_success
+  assert_output_contains_not '  PROMPT_COMMAND="_pyenv_virtualenv_hook;$PROMPT_COMMAND";'
+}
+
+@test "detect parent shell from script (bash)" {
+  unset PYENV_SHELL
+  printf '#!/bin/bash\necho "$(pyenv-virtualenv-init -)"' > ${BATS_TEST_DIRNAME}/script.sh
+  chmod +x ${BATS_TEST_DIRNAME}/script.sh
+  run ${BATS_TEST_DIRNAME}/script.sh
   assert_success
   assert_output_contains '  PROMPT_COMMAND="_pyenv_virtualenv_hook;$PROMPT_COMMAND";'
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -97,6 +97,16 @@ assert_output_contains() {
   }
 }
 
+assert_output_contains_not() {
+  local expected="$1"
+  echo "$output" | grep -F "$expected" >/dev/null && {
+    { echo "expected output to not contain $expected"
+      echo "actual: $output"
+    } | flunk; return
+  }
+  return 0
+}
+
 create_executable() {
   mkdir -p "${PYENV_ROOT}/versions/$1/bin"
   touch "${PYENV_ROOT}/versions/$1/bin/$2"


### PR DESCRIPTION
 - fixes `ps` command to lookup parent process
 - adds `assert_output_contains_not` test helper

Ref: https://github.com/yyuu/pyenv/issues/373