### PR TITLE
Manage Anaconda/Miniconda environment as a pyenv version

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -122,7 +122,7 @@ if [ -n "${conda_env}" ]; then
   cat <<EOS
 unset PYENV_DEACTIVATE;
 export PYENV_ACTIVATE="${prefix}";
-. "${prefix%/envs/*}/bin/activate" "${versions##*/}"
+. "${prefix%/envs/*}/bin/activate" "${versions##*/}";
 EOS
 else
   # virtualenv/pyvenv

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -69,6 +69,29 @@ if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
 fi
 
 shell="${PYENV_SHELL:-${SHELL##*/}}"
+prefix="$(pyenv-prefix "${versions}")"
+
+unset conda_env
+
+if [ -f "${prefix}/bin/conda" ]; then
+  if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
+    case "$shell" in
+    bash )
+      conda_env="${prefix##*/envs/}"
+      ;;
+    zsh )
+      conda_env="${prefix##*/envs/}"
+      ;;
+    * )
+      echo "false"
+      exit 1
+      ;;
+    esac
+  else
+    echo "false"
+    exit 1
+  fi
+fi
 
 # Display setup instruction, if pyenv-virtualenv has not been initialized.
 # if 'pyenv virtualenv-init -' is not found in "$profile"
@@ -94,20 +117,29 @@ if [ -z "$no_shell" ]; then
   esac
 fi
 
-prefix="$(pyenv-prefix "${versions}")"
-case "$shell" in
-fish )
+if [ -n "${conda_env}" ]; then
+  # anaconda/miniconda
   cat <<EOS
+unset PYENV_DEACTIVATE;
+export PYENV_ACTIVATE="${prefix}";
+. "${prefix%/envs/*}/bin/activate" "${versions##*/}"
+EOS
+else
+  # virtualenv/pyvenv
+  case "$shell" in
+  fish )
+    cat <<EOS
 set -e PYENV_DEACTIVATE;
 setenv PYENV_ACTIVATE "${prefix}";
 . "${prefix}/bin/activate.fish";
 EOS
- ;;
-*    )
-  cat <<EOS
+   ;;
+  *    )
+    cat <<EOS
 unset PYENV_DEACTIVATE;
 export PYENV_ACTIVATE="${prefix}";
 . "${prefix}/bin/activate";
 EOS
-  ;;
-esac
+    ;;
+  esac
+fi

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -69,7 +69,12 @@ if pyenv-prefix "${versions}" 1>/dev/null 2>&1; then
     exit 1
   fi
 else
-  versions="$(pyenv-version-name)/envs/${versions}"
+  version="$(pyenv-version-name)"
+  if [[ "${versions}" == "root" ]]; then
+    versions="${version%/envs/*}"
+  else
+    versions="${version%/envs/*}/envs/${versions}"
+  fi
   if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
     [ -n "$NOERROR" ] || echo "pyenv-virtualenv: version \`${versions}' is not an environment of anaconda/miniconda" 1>&2
     echo "false"
@@ -83,22 +88,15 @@ prefix="$(pyenv-prefix "${versions}")"
 unset conda_env
 
 if [ -f "${prefix}/bin/conda" ]; then
-  if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
-    case "$shell" in
-    bash )
-      conda_env="${prefix##*/envs/}"
-      ;;
-    zsh )
-      conda_env="${prefix##*/envs/}"
-      ;;
-    * )
-      echo "false"
-      exit 1
-      ;;
-    esac
-  else
+  if [[ "$shell" != "bash" ]] && [[ "$shell" != "zsh" ]]; then
+    [ -n "$NOERROR" ] || echo "pyenv-virtualenv: Only bash and zsh are supported by Anaconda/Miniconda" 1>&2
     echo "false"
     exit 1
+  fi
+  if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
+    conda_env="${prefix##*/envs/}"
+  else
+    conda_env="root"
   fi
 fi
 
@@ -131,7 +129,7 @@ if [ -n "${conda_env}" ]; then
   cat <<EOS
 unset PYENV_DEACTIVATE;
 export PYENV_ACTIVATE="${prefix}";
-. "${prefix%/envs/*}/bin/activate" "${versions##*/}";
+. "${prefix%/envs/*}/bin/activate" "${conda_env}";
 EOS
 else
   # virtualenv/pyvenv

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -62,10 +62,19 @@ if [ "${#versions[@]}" -gt 1 ]; then
   exit 1
 fi
 
-if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
-  [ -n "$NOERROR" ] || echo "pyenv-virtualenv: version \`${versions}' is not a virtualenv" 1>&2
-  echo "false"
-  exit 1
+if pyenv-prefix "${versions}" 1>/dev/null 2>&1; then
+  if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
+    [ -n "$NOERROR" ] || echo "pyenv-virtualenv: version \`${versions}' is not a virtualenv" 1>&2
+    echo "false"
+    exit 1
+  fi
+else
+  versions="$(pyenv-version-name)/envs/${versions}"
+  if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
+    [ -n "$NOERROR" ] || echo "pyenv-virtualenv: version \`${versions}' is not an environment of anaconda/miniconda" 1>&2
+    echo "false"
+    exit 1
+  fi
 fi
 
 shell="${PYENV_SHELL:-${SHELL##*/}}"

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -33,22 +33,15 @@ prefix="${PYENV_ACTIVATE:-${VIRTUAL_ENV}}"
 unset conda_env
 
 if [ -f "${prefix}/bin/conda" ]; then
-  if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
-    case "$shell" in
-    bash )
-      conda_env="${prefix##*/envs/}"
-      ;;
-    zsh )
-      conda_env="${prefix##*/envs/}"
-      ;;
-    * )
-      echo "false"
-      exit 1
-      ;;
-    esac
-  else
+  if [[ "$shell" != "bash" ]] && [[ "$shell" != "zsh" ]]; then
+    [ -n "$NOERROR" ] || echo "pyenv-virtualenv: Only bash and zsh are supported by Anaconda/Miniconda" 1>&2
     echo "false"
     exit 1
+  fi
+  if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
+    conda_env="${prefix##*/envs/}"
+  else
+    conda_env="root"
   fi
 fi
 

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -28,16 +28,42 @@ while [ $# -gt 0 ]; do
 done
 
 shell="$(basename "${PYENV_SHELL:-$SHELL}")"
-case "$shell" in
-fish )
-  echo "if functions -q deactivate;"
-  ;;
-*    )
-  echo "if declare -f deactivate 1>/dev/null 2>&1; then"
-  ;;
-esac
-
 prefix="${PYENV_ACTIVATE:-${VIRTUAL_ENV}}"
+
+unset conda_env
+
+if [ -f "${prefix}/bin/conda" ]; then
+  if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
+    case "$shell" in
+    bash )
+      conda_env="${prefix##*/envs/}"
+      ;;
+    zsh )
+      conda_env="${prefix##*/envs/}"
+      ;;
+    * )
+      echo "false"
+      exit 1
+      ;;
+    esac
+  else
+    echo "false"
+    exit 1
+  fi
+fi
+
+if [ -n "${conda_env}" ]; then
+  echo "if [ -f \"${prefix%/envs/*}/bin/deactivate\" ]; then"
+else
+  case "$shell" in
+  fish )
+    echo "if functions -q deactivate;"
+    ;;
+  *    )
+    echo "if declare -f deactivate 1>/dev/null 2>&1; then"
+    ;;
+  esac
+fi
 
 if [ -n "$VERBOSE" ]; then
   echo "  echo \"pyenv-virtualenv: deactivate ${prefix##*/}\" 1>&2;"
@@ -57,24 +83,33 @@ if [ -n "${PYENV_ACTIVATE_SHELL}" ]; then
   esac
 fi
 
-case "$shell" in
-fish )
+if [ -n "${conda_env}" ]; then
   cat <<EOS
+  export PYENV_DEACTIVATE="$prefix";
+  unset PYENV_ACTIVATE;
+  . "${prefix%/envs/*}/bin/deactivate" "${prefix##*/envs/}";
+else
+EOS
+else
+  case "$shell" in
+  fish )
+    cat <<EOS
   setenv PYENV_DEACTIVATE "$prefix";
   set -e PYENV_ACTIVATE;
   deactivate;
 else;
 EOS
-  ;;
-*    )
-  cat <<EOS
+    ;;
+  *    )
+    cat <<EOS
   export PYENV_DEACTIVATE="$prefix";
   unset PYENV_ACTIVATE;
   deactivate;
 else
 EOS
-  ;;
-esac
+    ;;
+  esac
+fi
 
 if [ -z "$NOERROR" ]; then
   echo "  echo \"pyenv-virtualenv: no virtualenv has been activated.\" 1>&2;"

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -87,7 +87,7 @@ if [ -n "${conda_env}" ]; then
   cat <<EOS
   export PYENV_DEACTIVATE="$prefix";
   unset PYENV_ACTIVATE;
-  . "${prefix%/envs/*}/bin/deactivate" "${prefix##*/envs/}";
+  . "${prefix%/envs/*}/bin/deactivate";
 else
 EOS
 else

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -115,21 +115,21 @@ if [[ "$shell" != "fish" ]]; then
   cat <<EOS
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
-      pyenv deactivate --no-error --verbose
+      eval "\$(pyenv sh-deactivate --no-error --verbose)"
       unset PYENV_DEACTIVATE
       return 0
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      if pyenv deactivate --no-error --verbose; then
+      if eval "\$(pyenv sh-deactivate --no-error --verbose)"; then
         unset PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
+        eval "\$(pyenv sh-activate --no-error --verbose)" || unset PYENV_DEACTIVATE
       else
-        pyenv activate --no-error --verbose
+        eval "\$(pyenv sh-activate --no-error --verbose)"
       fi
     fi
   else
     if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose || true
+      eval "\$(pyenv sh-activate --no-error --verbose)" || true
     fi
   fi
 };

--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -50,8 +50,7 @@ for version_string in "${versions[@]}"; do
           exit 1
         fi
       else
-        echo "pyenv-virtualenv: version \`${version_string}' is not a virtualenv" 1>&2
-        exit 1
+        VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "${PREFIX}")
       fi
     else
       VIRTUALENV_PREFIX_PATH="$(real_prefix "${version}" || base_prefix "${version}" || true)"

--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -44,7 +44,7 @@ for version_string in "${versions[@]}"; do
       if [[ "${version_string}" != "${version_string%/envs/*}" ]]; then
         conda_env="${version_string##*/envs/}"
         if [ -f "${PREFIX}/envs/${conda_env}/bin/conda" ]; then
-          VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "${PREFIX}/envs/${conda_env}")
+          VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "${PREFIX}")
         else
           echo "pyenv-virtualenv: version \`${version_string}' is not an environment of anaconda/miniconda" 1>&2
           exit 1

--- a/bin/pyenv-virtualenv-prefix
+++ b/bin/pyenv-virtualenv-prefix
@@ -31,7 +31,8 @@ base_prefix() { # pyvenv
 }
 
 VIRTUALENV_PREFIX_PATHS=()
-for version in "${versions[@]}"; do
+for version_string in "${versions[@]}"; do
+  version="${version_string%%/*}"
   if [ "$version" = "system" ]; then
     echo "pyenv-virtualenv: version \`${version}' is not a virtualenv" 1>&2
     exit 1
@@ -40,8 +41,18 @@ for version in "${versions[@]}"; do
   if [ -f "${PREFIX}/bin/activate" ]; then
     # Anaconda has `activate` script nevertheless it is not a virtual environment (#65)
     if [ -f "${PREFIX}/bin/conda" ]; then
-      echo "pyenv-virtualenv: version \`${version}' is an anaconda/miniconda" 1>&2
-      exit 1
+      if [[ "${version_string}" != "${version_string%/envs/*}" ]]; then
+        conda_env="${version_string##*/envs/}"
+        if [ -f "${PREFIX}/envs/${conda_env}/bin/conda" ]; then
+          VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "${PREFIX}/envs/${conda_env}")
+        else
+          echo "pyenv-virtualenv: version \`${version_string}' is not an environment of anaconda/miniconda" 1>&2
+          exit 1
+        fi
+      else
+        echo "pyenv-virtualenv: version \`${version_string}' is not a virtualenv" 1>&2
+        exit 1
+      fi
     else
       VIRTUALENV_PREFIX_PATH="$(real_prefix "${version}" || base_prefix "${version}" || true)"
       VIRTUALENV_PREFIX_PATHS=("${VIRTUALENV_PREFIX_PATHS[@]}" "$VIRTUALENV_PREFIX_PATH")

--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -51,6 +51,16 @@ for version in $(pyenv-versions --bare); do
     virtualenv_prefix="$(pyenv-virtualenv-prefix "${version}" 2>/dev/null || true)"
     if [ -d "${virtualenv_prefix}" ]; then
       print_version "${version}" " (created from ${virtualenv_prefix})"
+    else
+      # envs of anaconda/miniconda
+      prefix="$(pyenv-prefix "${version}")"
+      if [ -f "${prefix}/bin/activate" ] && [ -f "${prefix}/bin/conda" ]; then
+        shopt -s nullglob
+        for conda_env in "${prefix}/envs/"*; do
+          print_version "${version##*/}${conda_env#${prefix}}" " (created from ${prefix})"
+        done
+        shopt -u nullglob
+      fi
     fi
   fi
 done

--- a/bin/pyenv-virtualenvs
+++ b/bin/pyenv-virtualenvs
@@ -51,10 +51,9 @@ for version in $(pyenv-versions --bare); do
     virtualenv_prefix="$(pyenv-virtualenv-prefix "${version}" 2>/dev/null || true)"
     if [ -d "${virtualenv_prefix}" ]; then
       print_version "${version}" " (created from ${virtualenv_prefix})"
-    else
-      # envs of anaconda/miniconda
       prefix="$(pyenv-prefix "${version}")"
-      if [ -f "${prefix}/bin/activate" ] && [ -f "${prefix}/bin/conda" ]; then
+      if [ -f "${prefix}/bin/conda" ]; then
+        # envs of anaconda/miniconda
         shopt -s nullglob
         for conda_env in "${prefix}/envs/"*; do
           print_version "${version##*/}${conda_env#${prefix}}" " (created from ${prefix})"

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -13,6 +13,7 @@ setup() {
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate
 
@@ -33,6 +34,7 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate --verbose
@@ -55,6 +57,7 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate
@@ -84,6 +87,7 @@ EOS
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate
 
@@ -104,6 +108,7 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
+  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate
@@ -132,6 +137,7 @@ EOS
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
+  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
 
@@ -152,6 +158,7 @@ EOS
   export PYENV_VIRTUALENV_INIT=
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
+  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
@@ -179,6 +186,7 @@ EOS
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
+  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
 
@@ -199,6 +207,7 @@ EOS
   export PYENV_VIRTUALENV_INIT=
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
+  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
@@ -232,10 +241,12 @@ EOS
 
 @test "should fail if the version is not a virtualenv" {
   stub pyenv-virtualenv-prefix "3.3.3 : false"
+  stub pyenv-prefix "3.3.3 : echo \"${PYENV_ROOT}/versions/3.3.3\""
 
   run pyenv-sh-activate "3.3.3"
 
   unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
 
   assert_failure
   assert_output <<EOS
@@ -246,10 +257,12 @@ EOS
 
 @test "should fail if the version is not a virtualenv (no-error)" {
   stub pyenv-virtualenv-prefix "3.3.3 : false"
+  stub pyenv-prefix "3.3.3 : echo \"${PYENV_ROOT}/versions/3.3.3\""
 
   run pyenv-sh-activate --no-error "3.3.3"
 
   unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
 
   assert_failure
   assert_output <<EOS

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export HOME="${TMP}"
+  export PYENV_ROOT="${TMP}/pyenv"
+}
+
+@test "activate conda root from current version" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  create_conda "anaconda-2.3.0"
+  stub pyenv-version-name "echo anaconda-2.3.0"
+  stub pyenv-virtualenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+
+  PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0" run pyenv-sh-activate
+
+  unstub pyenv-version-name
+  unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<EOS
+unset PYENV_DEACTIVATE;
+export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0";
+. "${PYENV_ROOT}/versions/anaconda-2.3.0/bin/activate" "root";
+EOS
+}
+
+@test "activate conda root from current version (fish)" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  create_conda "anaconda-2.3.0"
+  stub pyenv-version-name "echo anaconda-2.3.0"
+  stub pyenv-virtualenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+
+  PYENV_SHELL="fish" PYENV_VERSION="anaconda-2.3.0" run pyenv-sh-activate
+
+  unstub pyenv-version-name
+  unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
+
+  assert_failure
+  assert_output <<EOS
+pyenv-virtualenv: Only bash and zsh are supported by Anaconda/Miniconda
+false
+EOS
+}
+
+@test "activate conda root from command-line argument" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  create_conda "anaconda-2.3.0"
+  create_conda "miniconda-3.9.1"
+  stub pyenv-virtualenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
+  stub pyenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
+  stub pyenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
+
+  PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0" run pyenv-sh-activate "miniconda-3.9.1"
+
+  unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<EOS
+pyenv shell "miniconda-3.9.1";
+export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
+export PYENV_ACTIVATE="${PYENV_ROOT}/versions/miniconda-3.9.1";
+. "${PYENV_ROOT}/versions/miniconda-3.9.1/bin/activate" "root";
+EOS
+}
+
+@test "activate conda env from current version" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  create_conda "anaconda-2.3.0" "foo"
+  stub pyenv-version-name "echo anaconda-2.3.0/envs/foo"
+  stub pyenv-virtualenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
+  stub pyenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
+  stub pyenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
+
+  PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0/envs/foo" run pyenv-sh-activate
+
+  unstub pyenv-version-name
+  unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<EOS
+unset PYENV_DEACTIVATE;
+export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
+. "${PYENV_ROOT}/versions/anaconda-2.3.0/bin/activate" "foo";
+EOS
+}
+
+@test "activate conda env from command-line argument" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  create_conda "anaconda-2.3.0" "foo"
+  create_conda "miniconda-3.9.1" "bar"
+  stub pyenv-virtualenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
+  stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
+  stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
+
+  PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0/envs/foo" run pyenv-sh-activate "miniconda-3.9.1/envs/bar"
+
+  unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<EOS
+pyenv shell "miniconda-3.9.1/envs/bar";
+export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
+export PYENV_ACTIVATE="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
+. "${PYENV_ROOT}/versions/miniconda-3.9.1/bin/activate" "bar";
+EOS
+}
+
+@test "activate conda env from command-line argument in short-form" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  create_conda "miniconda-3.9.1" "bar"
+  stub pyenv-prefix "bar : false"
+  stub pyenv-version-name " : echo miniconda-3.9.1"
+  stub pyenv-virtualenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
+  stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
+
+  PYENV_SHELL="bash" PYENV_VERSION="miniconda-3.9.1" run pyenv-sh-activate "bar"
+
+  unstub pyenv-prefix
+  unstub pyenv-version-name
+  unstub pyenv-virtualenv-prefix
+
+  assert_success
+  assert_output <<EOS
+pyenv shell "miniconda-3.9.1/envs/bar";
+export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
+export PYENV_ACTIVATE="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
+. "${PYENV_ROOT}/versions/miniconda-3.9.1/bin/activate" "bar";
+EOS
+}

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export PYENV_ROOT="${TMP}/pyenv"
+}
+
+@test "deactivate conda root" {
+  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0"
+  export PYENV_ACTIVATE_SHELL=
+
+  create_conda "anaconda-2.3.0"
+
+  PYENV_SHELL="bash" run pyenv-sh-deactivate
+
+  assert_success
+  assert_output <<EOS
+if [ -f "${PYENV_ROOT}/versions/anaconda-2.3.0/bin/deactivate" ]; then
+  export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
+  unset PYENV_ACTIVATE;
+  . "${PYENV_ROOT}/versions/anaconda-2.3.0/bin/deactivate";
+else
+  echo "pyenv-virtualenv: no virtualenv has been activated." 1>&2;
+  false;
+fi;
+EOS
+}
+
+@test "deactivate conda root (fish)" {
+  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0"
+  export PYENV_ACTIVATE_SHELL=
+
+  create_conda "anaconda-2.3.0"
+
+  PYENV_SHELL="fish" run pyenv-sh-deactivate
+
+  assert_failure
+  assert_output <<EOS
+pyenv-virtualenv: Only bash and zsh are supported by Anaconda/Miniconda
+false
+EOS
+}
+
+@test "deactivate conda env" {
+  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo"
+  export PYENV_ACTIVATE_SHELL=
+
+  create_conda "anaconda-2.3.0" "foo"
+
+  PYENV_SHELL="bash" run pyenv-sh-deactivate
+
+  assert_success
+  assert_output <<EOS
+if [ -f "${PYENV_ROOT}/versions/anaconda-2.3.0/bin/deactivate" ]; then
+  export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
+  unset PYENV_ACTIVATE;
+  . "${PYENV_ROOT}/versions/anaconda-2.3.0/bin/deactivate";
+else
+  echo "pyenv-virtualenv: no virtualenv has been activated." 1>&2;
+  false;
+fi;
+EOS
+}

--- a/test/conda-virtualenv-prefix.bats
+++ b/test/conda-virtualenv-prefix.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export PYENV_ROOT="${TMP}/pyenv"
+}
+
+@test "display conda root" {
+  create_conda "anaconda-2.3.0"
+
+  stub pyenv-version-name "echo anaconda-2.3.0"
+  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+
+  PYENV_VERSION="anaconda-2.3.0" run pyenv-virtualenv-prefix
+
+  unstub pyenv-version-name
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<OUT
+${PYENV_ROOT}/versions/anaconda-2.3.0
+OUT
+}
+
+@test "display conda env" {
+  create_conda "anaconda-2.3.0" "foo"
+
+  stub pyenv-version-name "echo anaconda-2.3.0/envs/foo"
+  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
+
+  PYENV_VERSION="anaconda-2.3.0/envs/foo" run pyenv-virtualenv-prefix
+
+  unstub pyenv-version-name
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<OUT
+${PYENV_ROOT}/versions/anaconda-2.3.0
+OUT
+}

--- a/test/deactivate.bats
+++ b/test/deactivate.bats
@@ -106,6 +106,7 @@ EOS
 
 @test "deactivate virtualenv which has been activated manually" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
+  export PYENV_ACTIVATE=
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate
@@ -203,6 +204,7 @@ EOS
 
 @test "deactivate virtualenv which has been activated manually (fish)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
+  export PYENV_ACTIVATE=
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate

--- a/test/init.bats
+++ b/test/init.bats
@@ -51,21 +51,21 @@ export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
-      pyenv deactivate --no-error --verbose
+      eval "\$(pyenv sh-deactivate --no-error --verbose)"
       unset PYENV_DEACTIVATE
       return 0
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      if pyenv deactivate --no-error --verbose; then
+      if eval "\$(pyenv sh-deactivate --no-error --verbose)"; then
         unset PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
+        eval "\$(pyenv sh-activate --no-error --verbose)" || unset PYENV_DEACTIVATE
       else
-        pyenv activate --no-error --verbose
+        eval "\$(pyenv sh-activate --no-error --verbose)"
       fi
     fi
   else
     if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose || true
+      eval "\$(pyenv sh-activate --no-error --verbose)" || true
     fi
   fi
 };
@@ -113,21 +113,21 @@ export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
-      pyenv deactivate --no-error --verbose
+      eval "\$(pyenv sh-deactivate --no-error --verbose)"
       unset PYENV_DEACTIVATE
       return 0
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      if pyenv deactivate --no-error --verbose; then
+      if eval "\$(pyenv sh-deactivate --no-error --verbose)"; then
         unset PYENV_DEACTIVATE
-        pyenv activate --no-error --verbose || unset PYENV_DEACTIVATE
+        eval "\$(pyenv sh-activate --no-error --verbose)" || unset PYENV_DEACTIVATE
       else
-        pyenv activate --no-error --verbose
+        eval "\$(pyenv sh-activate --no-error --verbose)"
       fi
     fi
   else
     if [ -z "\$VIRTUAL_ENV" ] && [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      pyenv activate --no-error --verbose || true
+      eval "\$(pyenv sh-activate --no-error --verbose)" || true
     fi
   fi
 };

--- a/test/init.bats
+++ b/test/init.bats
@@ -11,20 +11,22 @@ load test_helper
 
 @test "detect parent shell from script (sh)" {
   unset PYENV_SHELL
-  printf '#!/bin/sh\necho "$(pyenv-virtualenv-init -)"' > ${BATS_TEST_DIRNAME}/script.sh
-  chmod +x ${BATS_TEST_DIRNAME}/script.sh
-  run ${BATS_TEST_DIRNAME}/script.sh
+  printf '#!/bin/sh\necho "$(pyenv-virtualenv-init -)"' > "${TMP}/script.sh"
+  chmod +x ${TMP}/script.sh
+  run ${TMP}/script.sh
   assert_success
   assert_output_contains_not '  PROMPT_COMMAND="_pyenv_virtualenv_hook;$PROMPT_COMMAND";'
+  rm -f "${TMP}/script.sh"
 }
 
 @test "detect parent shell from script (bash)" {
   unset PYENV_SHELL
-  printf '#!/bin/bash\necho "$(pyenv-virtualenv-init -)"' > ${BATS_TEST_DIRNAME}/script.sh
-  chmod +x ${BATS_TEST_DIRNAME}/script.sh
-  run ${BATS_TEST_DIRNAME}/script.sh
+  printf '#!/bin/bash\necho "$(pyenv-virtualenv-init -)"' > "${TMP}/script.sh"
+  chmod +x ${TMP}/script.sh
+  run ${TMP}/script.sh
   assert_success
   assert_output_contains '  PROMPT_COMMAND="_pyenv_virtualenv_hook;$PROMPT_COMMAND";'
+  rm -f "${TMP}/script.sh"
 }
 
 @test "sh-compatible instructions" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -116,3 +116,19 @@ create_executable() {
 remove_executable() {
   rm -f "${PYENV_ROOT}/versions/$1/bin/$2"
 }
+
+create_conda() {
+  local version="$1"
+  shift 1
+  mkdir -p "${PYENV_ROOT}/versions/$version/bin"
+  touch "${PYENV_ROOT}/versions/$version/bin/activate"
+  touch "${PYENV_ROOT}/versions/$version/bin/conda"
+  chmod +x "${PYENV_ROOT}/versions/$version/bin/conda"
+  local conda_env
+  for conda_env; do
+    mkdir -p "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin"
+    touch "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/activate"
+    touch "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/conda"
+    chmod +x "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/conda"
+  done
+}

--- a/test/virtualenvs.bats
+++ b/test/virtualenvs.bats
@@ -17,12 +17,15 @@ setup() {
   stub pyenv-virtualenv-prefix "3.3.3 : false"
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/2.7.6\""
   stub pyenv-virtualenv-prefix "venv33 : echo \"${PYENV_ROOT}/versions/3.3.3\""
+  stub pyenv-prefix "2.7.6 : echo \"${PYENV_ROOT}/versions/2.7.6\""
+  stub pyenv-prefix "3.3.3 : echo \"${PYENV_ROOT}/versions/3.3.3\""
 
   run pyenv-virtualenvs
 
   unstub pyenv-version-name
   unstub pyenv-versions
   unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
 
   assert_success
   assert_output <<OUT

--- a/test/virtualenvs.bats
+++ b/test/virtualenvs.bats
@@ -17,8 +17,8 @@ setup() {
   stub pyenv-virtualenv-prefix "3.3.3 : false"
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/2.7.6\""
   stub pyenv-virtualenv-prefix "venv33 : echo \"${PYENV_ROOT}/versions/3.3.3\""
-  stub pyenv-prefix "2.7.6 : echo \"${PYENV_ROOT}/versions/2.7.6\""
-  stub pyenv-prefix "3.3.3 : echo \"${PYENV_ROOT}/versions/3.3.3\""
+  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/2.7.6\""
+  stub pyenv-prefix "venv33 : echo \"${PYENV_ROOT}/versions/3.3.3\""
 
   run pyenv-virtualenvs
 
@@ -39,12 +39,15 @@ OUT
   stub pyenv-versions "--bare : echo \"system\";echo \"venv27\";echo \"venv33\""
   stub pyenv-virtualenv-prefix "venv27 : echo \"/usr\""
   stub pyenv-virtualenv-prefix "venv33 : echo \"/usr\""
+  stub pyenv-prefix "venv27 : echo \"/usr\""
+  stub pyenv-prefix "venv33 : echo \"/usr\""
 
   run pyenv-virtualenvs
 
   unstub pyenv-version-name
   unstub pyenv-versions
   unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
 
   assert_success
   assert_output <<OUT
@@ -57,11 +60,14 @@ OUT
   stub pyenv-versions "--bare : echo \"system\";echo \"venv27\";echo \"venv33\""
   stub pyenv-virtualenv-prefix "venv27 : echo \"/usr\""
   stub pyenv-virtualenv-prefix "venv33 : echo \"/usr\""
+  stub pyenv-prefix "venv27 : echo \"/usr\""
+  stub pyenv-prefix "venv33 : echo \"/usr\""
 
   run pyenv-virtualenvs --bare
 
   unstub pyenv-versions
   unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
 
   assert_success
   assert_output <<OUT


### PR DESCRIPTION
With this patch, we can just simply specify a conda environment as `miniconda3-3.9.1/envs/myenv`.

```sh
% pyenv versions
  system
  2.7.10
  miniconda3-3.9.1
% pyenv shell miniconda3-3.9.1
discarding /home/yyuu/.pyenv/versions/miniconda3-3.9.1/bin from PATH
prepending /home/yyuu/.pyenv/versions/miniconda3-3.9.1/bin to PATH
(root)% conda env list
# conda environments:
#
myenv                    /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv
root                  *  /home/yyuu/.pyenv/versions/miniconda3-3.9.1
(root)% pyenv virtualenvs
* miniconda3-3.9.1 (created from /home/yyuu/.pyenv/versions/miniconda3-3.9.1)
  miniconda3-3.9.1/envs/myenv (created from /home/yyuu/.pyenv/versions/miniconda3-3.9.1)
(root)% pyenv activate myenv
discarding /home/yyuu/.pyenv/versions/miniconda3-3.9.1/bin from PATH
prepending /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv/bin to PATH
(myenv)% conda env list
# conda environments:
#
myenv                 *  /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv
root                     /home/yyuu/.pyenv/versions/miniconda3-3.9.1
(myenv)% pyenv virtualenvs
  miniconda3-3.9.1 (created from /home/yyuu/.pyenv/versions/miniconda3-3.9.1)
* miniconda3-3.9.1/envs/myenv (created from /home/yyuu/.pyenv/versions/miniconda3-3.9.1)
```