### PR TITLE
pyenv-virtualenv-init fix for fish

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -78,7 +78,7 @@ fish )
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l PYENV_PREFIX (pyenv prefix 2>/dev/null; or true)
   if [ -n "\$PYENV_ACTIVATE" ]
-    if [ "(pyenv version-name 2>/dev/null; or true)" = "system" ]
+    if [ (pyenv version-name 2>/dev/null; or true) = "system" ]
       pyenv deactivate --no-error --verbose
       set -e PYENV_DEACTIVATE
       return 0

--- a/test/init.bats
+++ b/test/init.bats
@@ -85,7 +85,7 @@ setenv PYENV_VIRTUALENV_INIT 1;
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l PYENV_PREFIX (pyenv prefix 2>/dev/null; or true)
   if [ -n "\$PYENV_ACTIVATE" ]
-    if [ "(pyenv version-name 2>/dev/null; or true)" = "system" ]
+    if [ (pyenv version-name 2>/dev/null; or true) = "system" ]
       pyenv deactivate --no-error --verbose
       set -e PYENV_DEACTIVATE
       return 0


### PR DESCRIPTION
In fish, the pyenv was not automatically being deactivated on directory change. Turns out that, because of the quotes, it was comparing the command string instead of the command output, which was never true. Removing the quotes resolved the issue.