### PR TITLE
Passing return value from executed command.

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -77,11 +77,12 @@ fish )
   cat <<EOS
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l PYENV_PREFIX (pyenv prefix 2>/dev/null; or true)
+  set -l ret \$status
   if [ -n "\$PYENV_ACTIVATE" ]
     if [ (pyenv version-name 2>/dev/null; or true) = "system" ]
       pyenv deactivate --no-error --verbose
       set -e PYENV_DEACTIVATE
-      return 0
+      return \$ret
     end
     if [ "\$PYENV_ACTIVATE" != "\$PYENV_PREFIX" ]
       if pyenv deactivate --no-error --verbose
@@ -96,6 +97,7 @@ function _pyenv_virtualenv_hook --on-event fish_prompt;
       pyenv activate --no-error --verbose; or true
     end
   end
+  return \$ret
 end
 EOS
  ;;
@@ -113,11 +115,12 @@ esac
 
 if [[ "$shell" != "fish" ]]; then
   cat <<EOS
+  local ret=\$?
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
       eval "\$(pyenv sh-deactivate --no-error --verbose)"
       unset PYENV_DEACTIVATE
-      return 0
+      return \$ret
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
       if eval "\$(pyenv sh-deactivate --no-error --verbose)"; then
@@ -132,6 +135,7 @@ if [[ "$shell" != "fish" ]]; then
       eval "\$(pyenv sh-activate --no-error --verbose)" || true
     fi
   fi
+  return \$ret
 };
 EOS
 

--- a/test/init.bats
+++ b/test/init.bats
@@ -51,11 +51,12 @@ load test_helper
   assert_output <<EOS
 export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
+  local ret=\$?
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
       eval "\$(pyenv sh-deactivate --no-error --verbose)"
       unset PYENV_DEACTIVATE
-      return 0
+      return \$ret
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
       if eval "\$(pyenv sh-deactivate --no-error --verbose)"; then
@@ -70,6 +71,7 @@ _pyenv_virtualenv_hook() {
       eval "\$(pyenv sh-activate --no-error --verbose)" || true
     fi
   fi
+  return \$ret
 };
 if ! [[ "\$PROMPT_COMMAND" =~ _pyenv_virtualenv_hook ]]; then
   PROMPT_COMMAND="_pyenv_virtualenv_hook;\$PROMPT_COMMAND";
@@ -84,11 +86,12 @@ EOS
 setenv PYENV_VIRTUALENV_INIT 1;
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l PYENV_PREFIX (pyenv prefix 2>/dev/null; or true)
+  set -l ret \$status
   if [ -n "\$PYENV_ACTIVATE" ]
     if [ (pyenv version-name 2>/dev/null; or true) = "system" ]
       pyenv deactivate --no-error --verbose
       set -e PYENV_DEACTIVATE
-      return 0
+      return \$ret
     end
     if [ "\$PYENV_ACTIVATE" != "\$PYENV_PREFIX" ]
       if pyenv deactivate --no-error --verbose
@@ -103,6 +106,7 @@ function _pyenv_virtualenv_hook --on-event fish_prompt;
       pyenv activate --no-error --verbose; or true
     end
   end
+  return \$ret
 end
 EOS
 }
@@ -113,11 +117,12 @@ EOS
   assert_output <<EOS
 export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
+  local ret=\$?
   if [ -n "\$PYENV_ACTIVATE" ]; then
     if [ "\$(pyenv version-name 2>/dev/null || true)" = "system" ]; then
       eval "\$(pyenv sh-deactivate --no-error --verbose)"
       unset PYENV_DEACTIVATE
-      return 0
+      return \$ret
     fi
     if [ "\$PYENV_ACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
       if eval "\$(pyenv sh-deactivate --no-error --verbose)"; then
@@ -132,6 +137,7 @@ _pyenv_virtualenv_hook() {
       eval "\$(pyenv sh-activate --no-error --verbose)" || true
     fi
   fi
+  return \$ret
 };
 typeset -g -a precmd_functions
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then


### PR DESCRIPTION
It is not possible to read "exit status" of executed command by using for example `echo $?`. The problem is with the function `_pyenv_virtualenv_hook` which always returns 0. Saving and returning previous exit code should help.