### PR TITLE
init: zsh: prepend hook to precmd_functions

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -151,7 +151,7 @@ EOS
     cat <<EOS
 typeset -g -a precmd_functions
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
-  precmd_functions+=_pyenv_virtualenv_hook;
+  precmd_functions=(_pyenv_virtualenv_hook \$precmd_functions);
 fi
 EOS
     ;;

--- a/test/init.bats
+++ b/test/init.bats
@@ -141,7 +141,7 @@ _pyenv_virtualenv_hook() {
 };
 typeset -g -a precmd_functions
 if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
-  precmd_functions+=_pyenv_virtualenv_hook;
+  precmd_functions=(_pyenv_virtualenv_hook \$precmd_functions);
 fi
 EOS
 }


### PR DESCRIPTION
This makes sure that $VIRTUAL_ENV is handled already in other precmd
functions, especially your prompt.

The hack/workaround to achieve this yourself:

    precmd_functions=(_pyenv_virtualenv_hook $precmd_functions)
    eval "$(pyenv virtualenv-init -)"
