### PR TITLE
Create virtualenv inside `envs` directory as similar as Anaconda

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -300,7 +300,7 @@ fi
 
 VIRTUALENV_PATH="${PYENV_ROOT}/versions/${VERSION_NAME}/envs/${VIRTUALENV_NAME}"
 
-COMPAT_VIRTUALENV_PATH="${PYENV_ROOT}/versions/${VIRTUALENV_NAME}" # TODO: create symlink?
+COMPAT_VIRTUALENV_PATH="${PYENV_ROOT}/versions/${VIRTUALENV_NAME}"
 if [ -e "${COMPAT_VIRTUALENV_PATH}" ] || [ -L "${COMPAT_VIRTUALENV_PATH}" ]; then
   echo "pyenv-virtualenv: \`${COMPAT_VIRTUALENV_PATH}' already exists." 1>&2
   exit 1

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -287,13 +287,24 @@ if ! pyenv-prefix 1>/dev/null 2>&1; then
   exit 1
 fi
 
+if pyenv-virtualenv-prefix "${VERSION_NAME}" 1>/dev/null 2>&1; then
+  echo "pyenv-virtualenv: nested virtualenv is not supported." 1>&2
+  exit 1
+fi
+
 if [ -z "$TMPDIR" ]; then
   TMP="/tmp"
 else
   TMP="${TMPDIR%/}"
 fi
 
-VIRTUALENV_PATH="${PYENV_ROOT}/versions/${VIRTUALENV_NAME}"
+VIRTUALENV_PATH="${PYENV_ROOT}/versions/${VERSION_NAME}/envs/${VIRTUALENV_NAME}"
+
+COMPAT_VIRTUALENV_PATH="${PYENV_ROOT}/versions/${VIRTUALENV_NAME}" # TODO: create symlink?
+if [ -e "${COMPAT_VIRTUALENV_PATH}" ] || [ -L "${COMPAT_VIRTUALENV_PATH}" ]; then
+  echo "pyenv-virtualenv: \`${COMPAT_VIRTUALENV_PATH}' already exists." 1>&2
+  exit 1
+fi
 
 unset HAS_VIRTUALENV
 unset HAS_PYVENV
@@ -400,7 +411,7 @@ if [ -d "${VIRTUALENV_PATH}/bin" ]; then
   fi
 
   if [ -n "$UPGRADE" ]; then
-    PYENV_VERSION="${VIRTUALENV_NAME}" prepare_requirements
+    PYENV_VERSION="${VERSION_NAME}/envs/${VIRTUALENV_NAME}" prepare_requirements
   fi
 fi
 
@@ -422,11 +433,16 @@ mkdir -p "${PYENV_VIRTUALENV_CACHE_PATH}"
 cd "${PYENV_VIRTUALENV_CACHE_PATH}"
 venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
 
+## Create symlink in the `versions` directory for backward compatibility
+if [ -d "${VIRTUALENV_PATH}" ]; then
+  ln -fs "${VIRTUALENV_PATH}" "${COMPAT_VIRTUALENV_PATH}"
+fi
+
 ## Install setuptools and pip.
-PYENV_VERSION="${VIRTUALENV_NAME}" build_package_ensurepip
+PYENV_VERSION="${VERSION_NAME}/envs/${VIRTUALENV_NAME}" build_package_ensurepip
 
 ## Migrate previously installed packages from requirements.txt.
-PYENV_VERSION="${VIRTUALENV_NAME}" install_requirements || true
+PYENV_VERSION="${VERSION_NAME}/envs/${VIRTUALENV_NAME}" install_requirements || true
 
 # Execute `after_virtualenv` hooks.
 for hook in "${after_hooks[@]}"; do eval "$hook"; done

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -27,8 +27,8 @@ OUT
 
   assert_success
   assert_output <<-OUT
-before: ${PYENV_ROOT}/versions/venv
-PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/venv
+before: ${PYENV_ROOT}/versions/3.2.1/envs/venv
+PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 after: 0
 rehashed
 OUT

--- a/test/pip.bats
+++ b/test/pip.bats
@@ -25,8 +25,9 @@ unstub_pyenv() {
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-exec "pyvenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/venv/bin"
-  stub pyenv-exec "python -s -m ensurepip : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/venv/bin/pip"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.4.1/envs/venv/bin"
+  stub pyenv-exec "python -s -m ensurepip : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.4.1/envs/venv/bin/pip"
 
   remove_executable "3.4.1" "virtualenv"
   create_executable "3.4.1" "pyvenv"
@@ -35,11 +36,11 @@ unstub_pyenv() {
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.4.1 pyvenv ${PYENV_ROOT}/versions/venv
-PYENV_VERSION=venv python -s -m ensurepip
+PYENV_VERSION=3.4.1 pyvenv ${PYENV_ROOT}/versions/3.4.1/envs/venv
+PYENV_VERSION=3.4.1/envs/venv python -s -m ensurepip
 rehashed
 OUT
-  assert [ -e "${PYENV_ROOT}/versions/venv/bin/pip" ]
+  assert [ -e "${PYENV_ROOT}/versions/3.4.1/envs/venv/bin/pip" ]
 
   unstub_pyenv
   unstub pyenv-exec
@@ -50,9 +51,10 @@ OUT
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-exec "pyvenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/venv/bin"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.3.5/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : false"
-  stub pyenv-exec "python -s */get-pip.py : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/venv/bin/pip"
+  stub pyenv-exec "python -s */get-pip.py : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.3.5/envs/venv/bin/pip"
   stub curl true
 
   remove_executable "3.3.5" "virtualenv"
@@ -62,12 +64,12 @@ OUT
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.3.5 pyvenv ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.3.5 pyvenv ${PYENV_ROOT}/versions/3.3.5/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
-PYENV_VERSION=venv python -s ${TMP}/pyenv/cache/get-pip.py
+PYENV_VERSION=3.3.5/envs/venv python -s ${TMP}/pyenv/cache/get-pip.py
 rehashed
 OUT
-  assert [ -e "${PYENV_ROOT}/versions/venv/bin/pip" ]
+  assert [ -e "${PYENV_ROOT}/versions/3.3.5/envs/venv/bin/pip" ]
 
   unstub_pyenv
   unstub pyenv-exec

--- a/test/python.bats
+++ b/test/python.bats
@@ -30,14 +30,14 @@ teardown() {
   create_executable "2.7.8" "python2.7"
   remove_executable "2.7.9" "python2.7"
 
-  stub pyenv-exec "virtualenv --verbose --python=${PYENV_ROOT}/versions/2.7.8/bin/python2.7 ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv --verbose * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
   stub pyenv-which "python2.7 : echo ${PYENV_ROOT}/versions/2.7.8/bin/python2.7"
 
   run pyenv-virtualenv --verbose --python=python2.7 venv
 
   assert_output <<OUT
-PYENV_VERSION=2.7.8 virtualenv --verbose --python=${PYENV_ROOT}/versions/2.7.8/bin/python2.7 ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=2.7.8 virtualenv --verbose --python=${PYENV_ROOT}/versions/2.7.8/bin/python2.7 ${PYENV_ROOT}/versions/2.7.8/envs/venv
 OUT
   assert_success
 
@@ -54,7 +54,7 @@ OUT
   remove_executable "2.7.8" "python2.7"
   create_executable "2.7.9" "python2.7"
 
-  stub pyenv-exec "virtualenv --verbose --python=${PYENV_ROOT}/versions/2.7.9/bin/python2.7 ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv --verbose * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
   stub pyenv-which "python2.7 : false"
   stub pyenv-whence "python2.7 : echo 2.7.7; echo 2.7.8; echo 2.7.9"
@@ -63,7 +63,7 @@ OUT
   run pyenv-virtualenv --verbose --python=python2.7 venv
 
   assert_output <<OUT
-PYENV_VERSION=2.7.8 virtualenv --verbose --python=${PYENV_ROOT}/versions/2.7.9/bin/python2.7 ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=2.7.8 virtualenv --verbose --python=${PYENV_ROOT}/versions/2.7.9/bin/python2.7 ${PYENV_ROOT}/versions/2.7.8/envs/venv
 OUT
   assert_success
 

--- a/test/pyvenv.bats
+++ b/test/pyvenv.bats
@@ -25,7 +25,8 @@ unstub_pyenv() {
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-exec "pyvenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
   remove_executable "3.4.1" "virtualenv"
@@ -35,7 +36,7 @@ unstub_pyenv() {
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.4.1 pyvenv ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.4.1 pyvenv ${PYENV_ROOT}/versions/3.4.1/envs/venv
 rehashed
 OUT
 
@@ -48,7 +49,8 @@ OUT
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-exec "virtualenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
   create_executable "3.4.1" "virtualenv"
@@ -58,7 +60,7 @@ OUT
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.4.1 virtualenv ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.4.1 virtualenv ${PYENV_ROOT}/versions/3.4.1/envs/venv
 rehashed
 OUT
 
@@ -71,8 +73,9 @@ OUT
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
-  stub pyenv-exec "virtualenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
@@ -85,7 +88,7 @@ OUT
   assert_success
   assert_output <<OUT
 PYENV_VERSION=3.2.1 pip install virtualenv
-PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
@@ -100,8 +103,9 @@ OUT
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
-  stub pyenv-exec "virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
   remove_executable "3.4.1" "virtualenv"
@@ -111,7 +115,7 @@ OUT
 
   assert_output <<OUT
 PYENV_VERSION=3.4.1 pip install virtualenv
-PYENV_VERSION=3.4.1 virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.4.1 virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/3.4.1/envs/venv
 rehashed
 OUT
   assert_success
@@ -125,8 +129,9 @@ OUT
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
-  stub pyenv-exec "virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
   remove_executable "3.4.1" "virtualenv"
@@ -136,7 +141,7 @@ OUT
 
   assert_output <<OUT
 PYENV_VERSION=3.4.1 pip install virtualenv
-PYENV_VERSION=3.4.1 virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.4.1 virtualenv --python=${TMP}/python3 ${PYENV_ROOT}/versions/3.4.1/envs/venv
 rehashed
 OUT
   assert_success
@@ -150,8 +155,9 @@ OUT
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PIP_REQUIRE_VENV=\${PIP_REQUIRE_VENV} PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
-  stub pyenv-exec "virtualenv ${PYENV_ROOT}/versions/venv : echo PIP_REQUIRE_VENV=\${PIP_REQUIRE_VENV} PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PIP_REQUIRE_VENV=\${PIP_REQUIRE_VENV} PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
@@ -164,7 +170,7 @@ OUT
   assert_success
   assert_output <<OUT
 PIP_REQUIRE_VENV= PYENV_VERSION=3.2.1 pip install virtualenv
-PIP_REQUIRE_VENV= PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/venv
+PIP_REQUIRE_VENV= PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT

--- a/test/virtualenv.bats
+++ b/test/virtualenv.bats
@@ -13,6 +13,7 @@ stub_pyenv() {
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-hooks "virtualenv : echo"
   stub pyenv-rehash " : echo rehashed"
 }
@@ -26,7 +27,7 @@ unstub_pyenv() {
 @test "create virtualenv from given version" {
   export PYENV_VERSION="3.2.1"
   stub_pyenv "${PYENV_VERSION}"
-  stub pyenv-exec "virtualenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
@@ -35,7 +36,7 @@ unstub_pyenv() {
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
@@ -49,7 +50,7 @@ OUT
   export PYENV_VERSION="3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-version-name "echo \${PYENV_VERSION}"
-  stub pyenv-exec "virtualenv ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
@@ -58,7 +59,7 @@ OUT
 
   assert_success
   assert_output <<OUT
-PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
@@ -73,7 +74,7 @@ OUT
   export PYENV_VERSION="3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-version-name "echo \${PYENV_VERSION}"
-  stub pyenv-exec "virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
@@ -81,7 +82,7 @@ OUT
   run pyenv-virtualenv -v -p ${TMP}/python venv
 
   assert_output <<OUT
-PYENV_VERSION=3.2.1 virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.2.1 virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/versions/3.2.1/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT
@@ -97,7 +98,7 @@ OUT
   export PYENV_VERSION="3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-version-name "echo \${PYENV_VERSION}"
-  stub pyenv-exec "virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/versions/venv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
@@ -105,7 +106,7 @@ OUT
   run pyenv-virtualenv --verbose --python=${TMP}/python venv
 
   assert_output <<OUT
-PYENV_VERSION=3.2.1 virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/versions/venv
+PYENV_VERSION=3.2.1 virtualenv --verbose --python=${TMP}/python ${PYENV_ROOT}/versions/3.2.1/envs/venv
 Installing pip from https://bootstrap.pypa.io/get-pip.py...
 rehashed
 OUT


### PR DESCRIPTION
This changes the installation path of virtualenv as similar as Anaconda/Miniconda. This would be reasonable since every virtualenvs are actually depending on its source version, and they cannot work alone.

This is a kind of breaking change. To mitigate the migration cost, I prepared a symlink of `COMPAT_VIRTUALENV_PATH` for backward compatibility.