### PR TITLE
Change `activate` behavior on multiple versions

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -14,6 +14,7 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
+unset DEACTIVATE
 unset QUIET
 unset VERBOSE
 
@@ -23,6 +24,9 @@ while [ $# -gt 0 ]; do
     # Provide pyenv completions
     echo --unset
     exec pyenv-virtualenvs --bare
+    ;;
+  "--deactivate" )
+    DEACTIVATE=1
     ;;
   "--no-error" | "--quiet" )
     QUIET=1
@@ -56,30 +60,40 @@ if [ -z "${PYENV_VIRTUALENV_INIT}" ]; then
   no_shell=
 fi
 
-if [ "${#versions[@]}" -gt 1 ]; then
-  [ -n "$QUIET" ] || echo "pyenv-virtualenv: cannot activate multiple versions at once: ${versions[@]}" 1>&2
+venv="${versions}"
+
+if ! pyenv-virtualenv-prefix "${venv}" 1>/dev/null 2>&1; then
+  if [ -z "$QUIET" ]; then
+    echo "pyenv-virtualenv: version \`${venv}' is not a virtualenv" 1>&2
+  fi
   echo "false"
   exit 1
 fi
 
-if pyenv-prefix "${versions}" 1>/dev/null 2>&1; then
-  if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
-    [ -n "$QUIET" ] || echo "pyenv-virtualenv: version \`${versions}' is not a virtualenv" 1>&2
-    echo "false"
-    exit 1
+# exit as error if there are multiple virtualenvs
+# https://github.com/yyuu/pyenv-virtualenv/issues/105
+for version in "${versions[@]}"; do
+  if [[ "${version}" != "${venv}" ]]; then
+    if pyenv-virtualenv-prefix "${version}" 1>/dev/null 2>&1; then
+      if [ -z "$QUIET" ]; then
+        echo "pyenv-virtualenv: cannot activate multiple versions at once: ${versions[@]}" 1>&2
+      fi
+      echo "false"
+      exit 1
+    fi
   fi
-else
-  version="$(pyenv-version-name)"
-  versions="${version%/envs/*}/envs/${versions}"
-  if ! pyenv-virtualenv-prefix "${versions}" 1>/dev/null 2>&1; then
-    [ -n "$QUIET" ] || echo "pyenv-virtualenv: version \`${versions}' is not an environment of anaconda/miniconda" 1>&2
-    echo "false"
-    exit 1
-  fi
-fi
+done
 
 shell="${PYENV_SHELL:-${SHELL##*/}}"
-prefix="$(pyenv-prefix "${versions}")"
+prefix="$(pyenv-prefix "${venv}")"
+
+if [[ "${VIRTUAL_ENV}" == "${prefix}" ]]; then
+  if [ -z "${QUIET}" ]; then
+    echo "pyenv-virtualenv: version \`${venv}' is already activated" 1>&2
+  fi
+  echo "true"
+  exit 0
+fi
 
 # Display setup instruction, if pyenv-virtualenv has not been initialized.
 # if 'pyenv virtualenv-init -' is not found in "$profile"
@@ -87,36 +101,33 @@ if [ -z "$PYENV_VIRTUALENV_INIT" ]; then
   pyenv-virtualenv-init >&2 || true
 fi
 
-echo "pyenv-virtualenv: activate ${versions}" 1>&2
-
-if [ -z "$no_shell" ]; then
-  echo "pyenv shell \"${versions}\";"
-  # shell version set in pyenv-sh-activate should be unset
-  # https://github.com/yyuu/pyenv-virtualenv/issues/61
-  case "$shell" in
-  fish )
-    echo "setenv PYENV_ACTIVATE_SHELL 1;"
-    ;;
-  * )
-    echo "export PYENV_ACTIVATE_SHELL=1;"
-    ;;
-  esac
+if [ -n "${DEACTIVATE}" ]; then
+  pyenv-sh-deactivate ${QUIET+--quiet} ${VERBOSE+--verbose}
 fi
 
-case "${shell}" in
-fish )
-  cat <<EOS
-set -e PYENV_DEACTIVATE;
-setenv PYENV_ACTIVATE "${prefix}";
+echo "pyenv-virtualenv: activate ${venv}" 1>&2
+
+if [ -z "$no_shell" ]; then
+  # shell version set in pyenv-sh-activate should be unset
+  # https://github.com/yyuu/pyenv-virtualenv/issues/61
+  OLDIFS="$IFS"
+  IFS=:
+  case "$shell" in
+  fish )
+    cat <<EOS
+setenv PYENV_VERSION "${versions[*]}";
+setenv PYENV_ACTIVATE_SHELL 1;
 EOS
-  ;;
-* )
-  cat <<EOS
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${prefix}";
+    ;;
+  * )
+    cat <<EOS
+export PYENV_VERSION="${versions[*]}";
+export PYENV_ACTIVATE_SHELL=1;
 EOS
-  ;;
-esac
+    ;;
+  esac
+  IFS="$OLDIFS"
+fi
 
 # virtualenv/pyvenv
 case "${shell}" in
@@ -130,8 +141,8 @@ esac
 
 # anaconda/miniconda
 if [ -x "${prefix}/bin/conda" ]; then
-  if [[ "${versions}" != "${versions%/envs/*}" ]]; then
-    CONDA_DEFAULT_ENV="${versions##*/envs/}"
+  if [[ "${venv}" != "${venv%/envs/*}" ]]; then
+    CONDA_DEFAULT_ENV="${venv##*/envs/}"
   else
     CONDA_DEFAULT_ENV="root"
   fi

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -26,20 +26,20 @@ while [ $# -gt 0 ]; do
     echo --unset
     exec pyenv-virtualenvs --bare
     ;;
-  "--deactivate" )
+  "-d" | "--deactivate" )
     DEACTIVATE=1
     ;;
-  "--force" )
+  "-f" | "--force" )
     FORCE=1
     ;;
-  "--no-error" | "--quiet" )
+  "-q" | "--quiet" )
     QUIET=1
     ;;
   "--unset" )
     echo "pyenv deactivate"
     exit
     ;;
-  "--verbose" )
+  "-v" | "--verbose" )
     VERBOSE=1
     ;;
   * )

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -15,6 +15,7 @@ set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
 unset DEACTIVATE
+unset FORCE
 unset QUIET
 unset VERBOSE
 
@@ -27,6 +28,9 @@ while [ $# -gt 0 ]; do
     ;;
   "--deactivate" )
     DEACTIVATE=1
+    ;;
+  "--force" )
+    FORCE=1
     ;;
   "--no-error" | "--quiet" )
     QUIET=1
@@ -95,6 +99,16 @@ if [[ "${VIRTUAL_ENV}" == "${prefix}" ]]; then
   exit 0
 fi
 
+if [[ "${PYENV_DEACTIVATE}" == "${prefix}" ]]; then
+  if [ -z "${FORCE}" ]; then
+    if [ -z "${QUIET}" ]; then
+      echo "pyenv-virtualenv: \`${venv}' is marked deactivated. use \`pyenv activate --force ${venv}' to activate forcibly." 1>&2
+    fi
+    echo "false"
+    exit 1
+  fi
+fi
+
 # Display setup instruction, if pyenv-virtualenv has not been initialized.
 # if 'pyenv virtualenv-init -' is not found in "$profile"
 if [ -z "$PYENV_VIRTUALENV_INIT" ]; then
@@ -132,10 +146,16 @@ fi
 # virtualenv/pyvenv
 case "${shell}" in
 fish )
-  echo "setenv VIRTUAL_ENV \"${prefix}\";"
+  cat <<EOS
+set -e PYENV_DEACTIVATE;
+setenv VIRTUAL_ENV "${prefix}";
+EOS
   ;;
 * )
-  echo "export VIRTUAL_ENV=\"${prefix}\";"
+  cat <<EOS
+unset PYENV_DEACTIVATE;
+export VIRTUAL_ENV="${prefix}";
+EOS
   ;;
 esac
 

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -27,50 +27,43 @@ while [ $# -gt 0 ]; do
   shift 1
 done
 
-shell="$(basename "${PYENV_SHELL:-$SHELL}")"
-prefix="${VIRTUAL_ENV:-${PYENV_ACTIVATE}}"
-
-if [ -z "${prefix}" ]; then
-  [ -n "$QUIET" ] || echo "pyenv-virtualenv: no virtualenv has been activated." 1>&2
+if [ -z "${VIRTUAL_ENV}" ]; then
+  if [ -z "$QUIET" ]; then
+    echo "pyenv-virtualenv: no virtualenv has been activated." 1>&2
+  fi
   echo "false"
   exit 1
 fi
 
+shell="$(basename "${PYENV_SHELL:-$SHELL}")"
+prefix="${VIRTUAL_ENV}"
+
 if [[ "${prefix}" != "${prefix%/envs/*}" ]]; then
-  version="$(basename "${prefix%/envs/*}")/envs/${prefix##*/}"
+  venv="$(basename "${prefix%/envs/*}")/envs/${prefix##*/}"
 else
-  version="${prefix##*/}"
+  venv="${prefix##*/}"
 fi
-echo "pyenv-virtualenv: deactivate ${version}" 1>&2
+
+echo "pyenv-virtualenv: deactivate ${venv}" 1>&2
 
 if [ -n "${PYENV_ACTIVATE_SHELL}" ]; then
   # shell version set in pyenv-sh-activate should be unset
   # https://github.com/yyuu/pyenv-virtualenv/issues/61
-  echo "pyenv shell --unset;"
   case "$shell" in
   fish )
-    echo "set -e PYENV_ACTIVATE_SHELL;"
+    cat <<EOS
+set -e PYENV_VERSION;
+set -e PYENV_ACTIVATE_SHELL;
+EOS
     ;;
   * )
-    echo "unset PYENV_ACTIVATE_SHELL;"
+    cat <<EOS
+unset PYENV_VERSION;
+unset PYENV_ACTIVATE_SHELL;
+EOS
     ;;
   esac
 fi
-
-case "${shell}" in
-fish )
-  cat <<EOS
-setenv PYENV_DEACTIVATE "$prefix";
-set -e PYENV_ACTIVATE;
-EOS
-  ;;
-* )
-  cat <<EOS
-export PYENV_DEACTIVATE="$prefix";
-unset PYENV_ACTIVATE;
-EOS
-  ;;
-esac
 
 # virtualenv/pyvenv
 case "${shell}" in

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -15,13 +15,13 @@ unset VERBOSE
 
 while [ $# -gt 0 ]; do
   case "$1" in
-  "--force" )
+  "-f" | "--force" )
     FORCE=1
     ;;
-  "--no-error" | "--quiet")
+  "-q" | "--quiet")
     QUIET=1
     ;;
-  "--verbose" )
+  "-v" | "--verbose" )
     VERBOSE=1
     ;;
   * )

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -9,11 +9,15 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
+unset FORCE
 unset QUIET
 unset VERBOSE
 
 while [ $# -gt 0 ]; do
   case "$1" in
+  "--force" )
+    FORCE=1
+    ;;
   "--no-error" | "--quiet")
     QUIET=1
     ;;
@@ -68,10 +72,16 @@ fi
 # virtualenv/pyvenv
 case "${shell}" in
 fish )
-  echo "set -e VIRTUAL_ENV;"
+  cat <<EOS
+setenv PYENV_DEACTIVATE "${VIRTUAL_ENV}";
+set -e VIRTUAL_ENV;
+EOS
   ;;
 * )
-  echo "unset VIRTUAL_ENV;"
+  cat <<EOS
+export PYENV_DEACTIVATE="${VIRTUAL_ENV}";
+unset VIRTUAL_ENV;
+EOS
   ;;
 esac
 

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -104,14 +104,9 @@ fish )
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
-    if [ "\$VIRTUAL_ENV" != (pyenv prefix 2>/dev/null; or true) ]
-      pyenv deactivate --quiet; or true
-      pyenv activate --quiet; or true
-    end
+    pyenv activate --deactivate --quiet; or pyenv deactivate --quiet; or true
   else
-    if [ "\$PYENV_DEACTIVATE" != (pyenv prefix 2>/dev/null; or true) ]
-      pyenv activate --quiet; or true
-    end
+    pyenv activate --quiet; or true
   end
   return \$ret
 end
@@ -133,14 +128,9 @@ if [[ "$shell" != "fish" ]]; then
   cat <<EOS
   local ret=\$?
   if [ -n "\$VIRTUAL_ENV" ]; then
-    if [ "\$VIRTUAL_ENV" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      eval "\$(pyenv sh-deactivate --quiet || true)" || true
-      eval "\$(pyenv sh-activate --quiet || true)" || true
-    fi
+    eval "\$(pyenv sh-activate --deactivate --quiet || pyenv sh-deactivate --quiet || true)" || true
   else
-    if [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      eval "\$(pyenv sh-activate --quiet || true)" || true
-    fi
+    eval "\$(pyenv sh-activate --quiet || true)" || true
   fi
   return \$ret
 };

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -23,6 +23,7 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -43,6 +44,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -70,6 +72,7 @@ eval "\$(pyenv virtualenv-init -)"
 pyenv-virtualenv: activate venv
 export PYENV_VERSION="venv";
 export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -90,6 +93,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv
+set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -117,6 +121,7 @@ status --is-interactive; and . (pyenv virtualenv-init -|psub)
 pyenv-virtualenv: activate venv
 setenv PYENV_VERSION "venv";
 setenv PYENV_ACTIVATE_SHELL 1;
+set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -137,6 +142,7 @@ EOS
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -162,6 +168,7 @@ eval "\$(pyenv virtualenv-init -)"
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -182,6 +189,7 @@ EOS
 pyenv-virtualenv: activate venv27
 setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
+set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -207,6 +215,7 @@ status --is-interactive; and . (pyenv virtualenv-init -|psub)
 pyenv-virtualenv: activate venv27
 setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
+set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -309,6 +318,7 @@ EOS
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27:2.7.10";
 export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 EOS
 }

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -13,7 +13,6 @@ setup() {
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
-  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate
 
@@ -24,8 +23,6 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -35,7 +32,6 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
-  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate --verbose
@@ -47,8 +43,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -58,7 +52,6 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
-  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate
@@ -75,10 +68,8 @@ EOS
 eval "\$(pyenv virtualenv-init -)"
 
 pyenv-virtualenv: activate venv
-pyenv shell "venv";
+export PYENV_VERSION="venv";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -88,7 +79,6 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
-  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate
@@ -100,8 +90,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv
-set -e PYENV_DEACTIVATE;
-setenv PYENV_ACTIVATE "${PYENV_ROOT}/versions/venv";
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -111,7 +99,6 @@ EOS
 
   stub pyenv-version-name "echo venv"
   stub pyenv-virtualenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
-  stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
   stub pyenv-prefix "venv : echo \"${PYENV_ROOT}/versions/venv\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate
@@ -128,10 +115,8 @@ EOS
 status --is-interactive; and . (pyenv virtualenv-init -|psub)
 
 pyenv-virtualenv: activate venv
-pyenv shell "venv";
+setenv PYENV_VERSION "venv";
 setenv PYENV_ACTIVATE_SHELL 1;
-set -e PYENV_DEACTIVATE;
-setenv PYENV_ACTIVATE "${PYENV_ROOT}/versions/venv";
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 EOS
 }
@@ -140,7 +125,6 @@ EOS
   export PYENV_VIRTUALENV_INIT=1
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
-  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
@@ -151,10 +135,8 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv27
-pyenv shell "venv27";
+export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv27";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -163,7 +145,6 @@ EOS
   export PYENV_VIRTUALENV_INIT=
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
-  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="bash" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
@@ -179,10 +160,8 @@ EOS
 eval "\$(pyenv virtualenv-init -)"
 
 pyenv-virtualenv: activate venv27
-pyenv shell "venv27";
+export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv27";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -191,7 +170,6 @@ EOS
   export PYENV_VIRTUALENV_INIT=1
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
-  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
@@ -202,10 +180,8 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate venv27
-pyenv shell "venv27";
+setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
-set -e PYENV_DEACTIVATE;
-setenv PYENV_ACTIVATE "${PYENV_ROOT}/versions/venv27";
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -214,7 +190,6 @@ EOS
   export PYENV_VIRTUALENV_INIT=
 
   stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
-  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
   stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
 
   PYENV_SHELL="fish" PYENV_VERSION="venv" run pyenv-sh-activate "venv27"
@@ -230,10 +205,8 @@ EOS
 status --is-interactive; and . (pyenv virtualenv-init -|psub)
 
 pyenv-virtualenv: activate venv27
-pyenv shell "venv27";
+setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
-set -e PYENV_DEACTIVATE;
-setenv PYENV_ACTIVATE "${PYENV_ROOT}/versions/venv27";
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 EOS
 }
@@ -249,12 +222,10 @@ EOS
 
 @test "should fail if the version is not a virtualenv" {
   stub pyenv-virtualenv-prefix "3.3.3 : false"
-  stub pyenv-prefix "3.3.3 : echo \"${PYENV_ROOT}/versions/3.3.3\""
 
   run pyenv-sh-activate "3.3.3"
 
   unstub pyenv-virtualenv-prefix
-  unstub pyenv-prefix
 
   assert_failure
   assert_output <<EOS
@@ -265,12 +236,10 @@ EOS
 
 @test "should fail if the version is not a virtualenv (quiet)" {
   stub pyenv-virtualenv-prefix "3.3.3 : false"
-  stub pyenv-prefix "3.3.3 : echo \"${PYENV_ROOT}/versions/3.3.3\""
 
   run pyenv-sh-activate --quiet "3.3.3"
 
   unstub pyenv-virtualenv-prefix
-  unstub pyenv-prefix
 
   assert_failure
   assert_output <<EOS
@@ -279,7 +248,12 @@ EOS
 }
 
 @test "should fail if there are multiple versions" {
+  stub pyenv-virtualenv-prefix "venv : true"
+  stub pyenv-virtualenv-prefix "venv27 : true"
+
   run pyenv-sh-activate "venv" "venv27"
+
+  unstub pyenv-virtualenv-prefix
 
   assert_failure
   assert_output <<EOS
@@ -288,12 +262,54 @@ false
 EOS
 }
 
-@test "should fail if there are multiple versions (quiet)" {
+@test "should fail if there are multiple virtualenvs (quiet)" {
+  stub pyenv-virtualenv-prefix "venv : true"
+  stub pyenv-virtualenv-prefix "venv27 : true"
+
   run pyenv-sh-activate --quiet "venv" "venv27"
+
+  unstub pyenv-virtualenv-prefix
 
   assert_failure
   assert_output <<EOS
 false
+EOS
+}
+
+@test "should fail if the first version is not a virtualenv" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  stub pyenv-virtualenv-prefix "2.7.10 : false"
+
+  run pyenv-sh-activate "2.7.10" "venv27"
+
+  unstub pyenv-virtualenv-prefix
+
+  assert_failure
+  assert_output <<EOS
+pyenv-virtualenv: version \`2.7.10' is not a virtualenv
+false
+EOS
+}
+
+@test "activate if the first virtualenv is a virtualenv" {
+  export PYENV_VIRTUALENV_INIT=1
+
+  stub pyenv-virtualenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
+  stub pyenv-virtualenv-prefix "2.7.10 : false"
+  stub pyenv-prefix "venv27 : echo \"${PYENV_ROOT}/versions/venv27\""
+
+  run pyenv-sh-activate "venv27" "2.7.10"
+
+  unstub pyenv-virtualenv-prefix
+  unstub pyenv-prefix
+
+  assert_success
+  assert_output <<EOS
+pyenv-virtualenv: activate venv27
+export PYENV_VERSION="venv27:2.7.10";
+export PYENV_ACTIVATE_SHELL=1;
+export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 EOS
 }
 

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -14,7 +14,6 @@ setup() {
   stub pyenv-version-name "echo anaconda-2.3.0"
   stub pyenv-virtualenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
   stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
-  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
 
   PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0" run pyenv-sh-activate
 
@@ -25,8 +24,6 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate anaconda-2.3.0
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0";
 export CONDA_DEFAULT_ENV="root";
 EOS
@@ -39,7 +36,6 @@ EOS
   stub pyenv-version-name "echo anaconda-2.3.0"
   stub pyenv-virtualenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
   stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
-  stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
 
   PYENV_SHELL="fish" PYENV_VERSION="anaconda-2.3.0" run pyenv-sh-activate
 
@@ -50,8 +46,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate anaconda-2.3.0
-set -e PYENV_DEACTIVATE;
-setenv PYENV_ACTIVATE "${TMP}/pyenv/versions/anaconda-2.3.0";
 setenv VIRTUAL_ENV "${TMP}/pyenv/versions/anaconda-2.3.0";
 setenv CONDA_DEFAULT_ENV "root";
 EOS
@@ -64,7 +58,6 @@ EOS
   create_conda "miniconda-3.9.1"
   stub pyenv-virtualenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
   stub pyenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
-  stub pyenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
 
   PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0" run pyenv-sh-activate "miniconda-3.9.1"
 
@@ -74,10 +67,8 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate miniconda-3.9.1
-pyenv shell "miniconda-3.9.1";
+export PYENV_VERSION="miniconda-3.9.1";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/miniconda-3.9.1";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1";
 export CONDA_DEFAULT_ENV="root";
 EOS
@@ -90,7 +81,6 @@ EOS
   stub pyenv-version-name "echo anaconda-2.3.0/envs/foo"
   stub pyenv-virtualenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
   stub pyenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
-  stub pyenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
 
   PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0/envs/foo" run pyenv-sh-activate
 
@@ -101,8 +91,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate anaconda-2.3.0/envs/foo
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 export CONDA_DEFAULT_ENV="foo";
 EOS
@@ -115,7 +103,6 @@ EOS
   create_conda "miniconda-3.9.1" "bar"
   stub pyenv-virtualenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
   stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
-  stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
 
   PYENV_SHELL="bash" PYENV_VERSION="anaconda-2.3.0/envs/foo" run pyenv-sh-activate "miniconda-3.9.1/envs/bar"
 
@@ -125,37 +112,8 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate miniconda-3.9.1/envs/bar
-pyenv shell "miniconda-3.9.1/envs/bar";
+export PYENV_VERSION="miniconda-3.9.1/envs/bar";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
-export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
-export CONDA_DEFAULT_ENV="bar";
-EOS
-}
-
-@test "activate conda env from command-line argument in short-form" {
-  export PYENV_VIRTUALENV_INIT=1
-
-  create_conda "miniconda-3.9.1" "bar"
-  stub pyenv-prefix "bar : false"
-  stub pyenv-version-name " : echo miniconda-3.9.1"
-  stub pyenv-virtualenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
-  stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
-
-  PYENV_SHELL="bash" PYENV_VERSION="miniconda-3.9.1" run pyenv-sh-activate "bar"
-
-  unstub pyenv-prefix
-  unstub pyenv-version-name
-  unstub pyenv-virtualenv-prefix
-
-  assert_success
-  assert_output <<EOS
-pyenv-virtualenv: activate miniconda-3.9.1/envs/bar
-pyenv shell "miniconda-3.9.1/envs/bar";
-export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
-export PYENV_ACTIVATE="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
 export CONDA_DEFAULT_ENV="bar";
 EOS

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -24,6 +24,7 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate anaconda-2.3.0
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0";
 export CONDA_DEFAULT_ENV="root";
 EOS
@@ -46,6 +47,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate anaconda-2.3.0
+set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${TMP}/pyenv/versions/anaconda-2.3.0";
 setenv CONDA_DEFAULT_ENV "root";
 EOS
@@ -69,6 +71,7 @@ EOS
 pyenv-virtualenv: activate miniconda-3.9.1
 export PYENV_VERSION="miniconda-3.9.1";
 export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1";
 export CONDA_DEFAULT_ENV="root";
 EOS
@@ -91,6 +94,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: activate anaconda-2.3.0/envs/foo
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 export CONDA_DEFAULT_ENV="foo";
 EOS
@@ -114,6 +118,7 @@ EOS
 pyenv-virtualenv: activate miniconda-3.9.1/envs/bar
 export PYENV_VERSION="miniconda-3.9.1/envs/bar";
 export PYENV_ACTIVATE_SHELL=1;
+unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
 export CONDA_DEFAULT_ENV="bar";
 EOS

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -8,7 +8,6 @@ setup() {
 
 @test "deactivate conda root" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0"
   export PYENV_ACTIVATE_SHELL=
   export CONDA_DEFAULT_ENV="root"
 
@@ -19,8 +18,6 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
 EOS
@@ -28,7 +25,6 @@ EOS
 
 @test "deactivate conda root (fish)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0"
   export PYENV_ACTIVATE_SHELL=
   export CONDA_DEFAULT_ENV="root"
 
@@ -40,8 +36,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0
-setenv PYENV_DEACTIVATE "${TMP}/pyenv/versions/anaconda-2.3.0";
-set -e PYENV_ACTIVATE;
 set -e VIRTUAL_ENV;
 set -e CONDA_DEFAULT_ENV;
 EOS
@@ -49,7 +43,6 @@ EOS
 
 @test "deactivate conda env" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo"
   export PYENV_ACTIVATE_SHELL=
   export CONDA_DEFAULT_ENV="foo"
 
@@ -61,8 +54,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0/envs/foo
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
 EOS

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -18,6 +18,7 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0";
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
 EOS
@@ -36,6 +37,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0
+setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/anaconda-2.3.0";
 set -e VIRTUAL_ENV;
 set -e CONDA_DEFAULT_ENV;
 EOS
@@ -54,6 +56,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0/envs/foo
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
 EOS

--- a/test/deactivate.bats
+++ b/test/deactivate.bats
@@ -15,6 +15,7 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 EOS
 }
@@ -28,6 +29,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 EOS
 }
@@ -41,6 +43,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 EOS
 }
@@ -56,6 +59,7 @@ EOS
 pyenv-virtualenv: deactivate venv
 unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 EOS
 }
@@ -71,6 +75,7 @@ EOS
 pyenv-virtualenv: deactivate venv
 unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 EOS
 }
@@ -84,6 +89,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 EOS
 }
@@ -97,6 +103,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 EOS
 }
@@ -110,6 +117,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 EOS
 }
@@ -125,6 +133,7 @@ EOS
 pyenv-virtualenv: deactivate venv
 set -e PYENV_VERSION;
 set -e PYENV_ACTIVATE_SHELL;
+setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 EOS
 }
@@ -140,6 +149,7 @@ EOS
 pyenv-virtualenv: deactivate venv
 set -e PYENV_VERSION;
 set -e PYENV_ACTIVATE_SHELL;
+setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 EOS
 }
@@ -153,6 +163,7 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
+setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 EOS
 }

--- a/test/deactivate.bats
+++ b/test/deactivate.bats
@@ -8,7 +8,6 @@ setup() {
 
 @test "deactivate virtualenv" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate
@@ -16,15 +15,12 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (verbose)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate --verbose
@@ -32,15 +28,12 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (quiet)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate --quiet
@@ -48,15 +41,12 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (with shell activation)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate
@@ -64,17 +54,14 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-pyenv shell --unset;
+unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (with shell activation) (quiet)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate --quiet
@@ -82,17 +69,14 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-pyenv shell --unset;
+unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
-export PYENV_DEACTIVATE="$PYENV_ACTIVATE";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv which has been activated manually" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE=
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate
@@ -100,15 +84,12 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="$VIRTUAL_ENV";
-unset PYENV_ACTIVATE;
 unset VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (fish)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate
@@ -116,15 +97,12 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-setenv PYENV_DEACTIVATE "$PYENV_ACTIVATE";
-set -e PYENV_ACTIVATE;
 set -e VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (fish) (quiet)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate --quiet
@@ -132,15 +110,12 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-setenv PYENV_DEACTIVATE "$PYENV_ACTIVATE";
-set -e PYENV_ACTIVATE;
 set -e VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (fish) (with shell activation)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate
@@ -148,17 +123,14 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-pyenv shell --unset;
+set -e PYENV_VERSION;
 set -e PYENV_ACTIVATE_SHELL;
-setenv PYENV_DEACTIVATE "$PYENV_ACTIVATE";
-set -e PYENV_ACTIVATE;
 set -e VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv (fish) (with shell activation) (quiet)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate --quiet
@@ -166,17 +138,14 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-pyenv shell --unset;
+set -e PYENV_VERSION;
 set -e PYENV_ACTIVATE_SHELL;
-setenv PYENV_DEACTIVATE "$PYENV_ACTIVATE";
-set -e PYENV_ACTIVATE;
 set -e VIRTUAL_ENV;
 EOS
 }
 
 @test "deactivate virtualenv which has been activated manually (fish)" {
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
-  export PYENV_ACTIVATE=
   export PYENV_ACTIVATE_SHELL=
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate
@@ -184,8 +153,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-setenv PYENV_DEACTIVATE "$VIRTUAL_ENV";
-set -e PYENV_ACTIVATE;
 set -e VIRTUAL_ENV;
 EOS
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -55,14 +55,9 @@ export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
   local ret=\$?
   if [ -n "\$VIRTUAL_ENV" ]; then
-    if [ "\$VIRTUAL_ENV" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      eval "\$(pyenv sh-deactivate --quiet || true)" || true
-      eval "\$(pyenv sh-activate --quiet || true)" || true
-    fi
+    eval "\$(pyenv sh-activate --deactivate --quiet || pyenv sh-deactivate --quiet || true)" || true
   else
-    if [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      eval "\$(pyenv sh-activate --quiet || true)" || true
-    fi
+    eval "\$(pyenv sh-activate --quiet || true)" || true
   fi
   return \$ret
 };
@@ -82,14 +77,9 @@ setenv PYENV_VIRTUALENV_INIT 1;
 function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
-    if [ "\$VIRTUAL_ENV" != (pyenv prefix 2>/dev/null; or true) ]
-      pyenv deactivate --quiet; or true
-      pyenv activate --quiet; or true
-    end
+    pyenv activate --deactivate --quiet; or pyenv deactivate --quiet; or true
   else
-    if [ "\$PYENV_DEACTIVATE" != (pyenv prefix 2>/dev/null; or true) ]
-      pyenv activate --quiet; or true
-    end
+    pyenv activate --quiet; or true
   end
   return \$ret
 end
@@ -106,14 +96,9 @@ export PYENV_VIRTUALENV_INIT=1;
 _pyenv_virtualenv_hook() {
   local ret=\$?
   if [ -n "\$VIRTUAL_ENV" ]; then
-    if [ "\$VIRTUAL_ENV" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      eval "\$(pyenv sh-deactivate --quiet || true)" || true
-      eval "\$(pyenv sh-activate --quiet || true)" || true
-    fi
+    eval "\$(pyenv sh-activate --deactivate --quiet || pyenv sh-deactivate --quiet || true)" || true
   else
-    if [ "\$PYENV_DEACTIVATE" != "\$(pyenv prefix 2>/dev/null || true)" ]; then
-      eval "\$(pyenv sh-activate --quiet || true)" || true
-    fi
+    eval "\$(pyenv sh-activate --quiet || true)" || true
   fi
   return \$ret
 };


### PR DESCRIPTION
If first version is a virtualenv, this will activate it even if there are multiple versions. It will not activate if there are multiple virtualenvs in the versions. I believe this fixes #105.

This also includes some of backward incompatible changes.

1. `PYENV_ACTIVATE` will never persist
1. Remove support for short-form name of `conda` style environments.
  * `env PYENV_VERSION=miniconda3-3.16.0 pyenv activate foo #==> activate miniconda3-3.16.0/envs/foo`