### PR TITLE
activate: discard output from `pyenv-sh-deactivate --quiet`

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -132,7 +132,7 @@ if [ -z "$PYENV_VIRTUALENV_INIT" ]; then
   pyenv-virtualenv-init >&2 || true
 fi
 
-pyenv-sh-deactivate --quiet ${VERBOSE+--verbose} || true
+pyenv-sh-deactivate --quiet ${VERBOSE+--verbose} 1>/dev/null || true
 
 echo "pyenv-virtualenv: activate ${venv}" 1>&2
 

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -33,7 +33,6 @@ setup() {
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate venv
 unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
@@ -58,7 +57,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate venv
 unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
@@ -88,7 +86,6 @@ EOS
 
 eval "\$(pyenv virtualenv-init -)"
 
-false
 pyenv-virtualenv: activate venv
 export PYENV_VERSION="venv";
 export PYENV_ACTIVATE_SHELL=1;
@@ -115,7 +112,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate venv
 set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
@@ -143,7 +139,6 @@ EOS
 
 status --is-interactive; and . (pyenv virtualenv-init -|psub)
 
-false
 pyenv-virtualenv: activate venv
 setenv PYENV_VERSION "venv";
 setenv PYENV_ACTIVATE_SHELL 1;
@@ -166,7 +161,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
@@ -196,7 +190,6 @@ EOS
 
 eval "\$(pyenv virtualenv-init -)"
 
-false
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
@@ -221,7 +214,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate venv27
 setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
@@ -249,7 +241,6 @@ EOS
 
 status --is-interactive; and . (pyenv virtualenv-init -|psub)
 
-false
 pyenv-virtualenv: activate venv27
 setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
@@ -361,7 +352,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27:2.7.10";
 export PYENV_ACTIVATE_SHELL=1;

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -34,7 +34,6 @@ setup() {
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate anaconda-2.3.0
 unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0";
@@ -61,7 +60,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate anaconda-2.3.0
 set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${TMP}/pyenv/versions/anaconda-2.3.0";
@@ -85,7 +83,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate miniconda-3.9.1
 export PYENV_VERSION="miniconda-3.9.1";
 export PYENV_ACTIVATE_SHELL=1;
@@ -114,7 +111,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate anaconda-2.3.0/envs/foo
 unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
@@ -140,7 +136,6 @@ EOS
 
   assert_success
   assert_output <<EOS
-false
 pyenv-virtualenv: activate miniconda-3.9.1/envs/bar
 export PYENV_VERSION="miniconda-3.9.1/envs/bar";
 export PYENV_ACTIVATE_SHELL=1;


### PR DESCRIPTION
Without this the [mktmpenv](https://github.com/blueyed/dotfiles/blob/master/usr/bin/mktmpenv) script I am using would fail, because of the `eval false`.