### PR TITLE
Remove `PYENV_DEACTIVATE`

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -14,6 +14,10 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
+if [ -z "${PYENV_ROOT}" ]; then
+  PYENV_ROOT="$(pyenv-root)"
+fi
+
 resolve_link() {
   $(type -p greadlink readlink | head -1) "$1"
 }
@@ -66,7 +70,7 @@ fi
 venv="${versions}"
 
 # exit as success if some virtualenv outside from pyenv is already activated
-if [ -n "${VIRTUAL_ENV}" ]; then
+if [ -n "${VIRTUAL_ENV}" ] && [[ "${VIRTUAL_ENV}" == "${VIRTUAL_ENV#${PYENV_ROOT}/versions/}" ]]; then
   if [ -z "${FORCE}" ]; then
     if [ -z "${QUIET}" ]; then
       echo "pyenv-virtualenv: virtualenv \`${VIRTUAL_ENV}' is already activated" 1>&2
@@ -77,7 +81,7 @@ if [ -n "${VIRTUAL_ENV}" ]; then
 fi
 
 if ! pyenv-virtualenv-prefix "${venv}" 1>/dev/null 2>&1; then
-  if [ -z "$QUIET" ]; then
+  if [ -z "${QUIET}" ]; then
     echo "pyenv-virtualenv: version \`${venv}' is not a virtualenv" 1>&2
   fi
   echo "false"
@@ -89,7 +93,7 @@ fi
 for version in "${versions[@]}"; do
   if [[ "${version}" != "${venv}" ]]; then
     if pyenv-virtualenv-prefix "${version}" 1>/dev/null 2>&1; then
-      if [ -z "$QUIET" ]; then
+      if [ -z "${QUIET}" ]; then
         echo "pyenv-virtualenv: cannot activate multiple versions at once: ${versions[@]}" 1>&2
       fi
       echo "false"
@@ -113,16 +117,6 @@ if [[ "${VIRTUAL_ENV}" == "${prefix}" ]]; then
     fi
     echo "true"
     exit 0
-  fi
-fi
-
-if [[ "${PYENV_DEACTIVATE}" == "${prefix}" ]]; then
-  if [ -z "${FORCE}" ]; then
-    if [ -z "${QUIET}" ]; then
-      echo "pyenv-virtualenv: \`${venv}' is marked deactivated. use \`pyenv activate --force ${venv}' to activate forcibly." 1>&2
-    fi
-    echo "false"
-    exit 1
   fi
 fi
 
@@ -161,16 +155,10 @@ fi
 # virtualenv/pyvenv
 case "${shell}" in
 fish )
-  cat <<EOS
-set -e PYENV_DEACTIVATE;
-setenv VIRTUAL_ENV "${prefix}";
-EOS
+  echo "setenv VIRTUAL_ENV \"${prefix}\";"
   ;;
 * )
-  cat <<EOS
-unset PYENV_DEACTIVATE;
-export VIRTUAL_ENV="${prefix}";
-EOS
+  echo "export VIRTUAL_ENV=\"${prefix}\";"
   ;;
 esac
 

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -70,7 +70,7 @@ fi
 venv="${versions}"
 
 # exit as success if some virtualenv outside from pyenv is already activated
-if [ -n "${VIRTUAL_ENV}" ] && [[ "${VIRTUAL_ENV}" == "${VIRTUAL_ENV#${PYENV_ROOT}/versions/}" ]]; then
+if [ -n "${VIRTUAL_ENV}" ] && [[ "${VIRTUAL_ENV}" != "${PYENV_ROOT}/versions/"* ]]; then
   if [ -z "${FORCE}" ]; then
     if [ -z "${QUIET}" ]; then
       echo "pyenv-virtualenv: virtualenv \`${VIRTUAL_ENV}' is already activated" 1>&2

--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -123,7 +123,9 @@ fi
 # Display setup instruction, if pyenv-virtualenv has not been initialized.
 # if 'pyenv virtualenv-init -' is not found in "$profile"
 if [ -z "$PYENV_VIRTUALENV_INIT" ]; then
-  pyenv-virtualenv-init >&2 || true
+  if [ -z "${QUIET}" ]; then
+    pyenv-virtualenv-init >&2 || true
+  fi
 fi
 
 pyenv-sh-deactivate --quiet ${VERBOSE+--verbose} || true

--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -32,11 +32,13 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "${VIRTUAL_ENV}" ]; then
-  if [ -z "$QUIET" ]; then
-    echo "pyenv-virtualenv: no virtualenv has been activated." 1>&2
+  if [ -z "${FORCE}" ]; then
+    if [ -z "${QUIET}" ]; then
+      echo "pyenv-virtualenv: no virtualenv has been activated." 1>&2
+    fi
+    echo "false"
+    exit 1
   fi
-  echo "false"
-  exit 1
 fi
 
 shell="$(basename "${PYENV_SHELL:-$SHELL}")"
@@ -72,19 +74,12 @@ fi
 # virtualenv/pyvenv
 case "${shell}" in
 fish )
-  cat <<EOS
-setenv PYENV_DEACTIVATE "${VIRTUAL_ENV}";
-set -e VIRTUAL_ENV;
-EOS
+  echo "set -e VIRTUAL_ENV;"
   ;;
 * )
-  cat <<EOS
-export PYENV_DEACTIVATE="${VIRTUAL_ENV}";
-unset VIRTUAL_ENV;
-EOS
+  echo "unset VIRTUAL_ENV;"
   ;;
 esac
-
 
 # anaconda/miniconda
 if [ -n "${CONDA_DEFAULT_ENV}" ]; then

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -11,16 +11,16 @@
 
 PYENV_VIRTUALENV_VERSION="20151103"
 
+if [ -z "${PYENV_ROOT}" ]; then
+  PYENV_ROOT="$(pyenv-root)"
+fi
+
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
   exec pyenv-versions --bare
-fi
-
-if [ -z "$PYENV_ROOT" ]; then
-  PYENV_ROOT="${HOME}/.pyenv"
 fi
 
 unset PIP_REQUIRE_VENV
@@ -105,7 +105,7 @@ version() {
   local version
   if [ -n "$USE_PYVENV" ]; then
     version="$(pyenv-which pyvenv 2>/dev/null || true)"
-    version="${version#$(pyenv-root)/versions/}"
+    version="${version#${PYENV_ROOT}/versions/}"
     version="${version%/bin/pyvenv}"
     echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (pyvenv ${version:-unknown})"
   else

--- a/test/activate.bats
+++ b/test/activate.bats
@@ -7,7 +7,6 @@ setup() {
   export PYENV_ROOT="${TMP}/pyenv"
   unset PYENV_VERSION
   unset PYENV_ACTIVATE_SHELL
-  unset PYENV_DEACTIVATE
   unset VIRTUAL_ENV
   unset CONDA_DEFAULT_ENV
   unset PYTHONHOME
@@ -35,7 +34,6 @@ setup() {
   assert_output <<EOS
 false
 pyenv-virtualenv: activate venv
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
@@ -60,7 +58,6 @@ EOS
   assert_output <<EOS
 false
 pyenv-virtualenv: activate venv
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
@@ -92,7 +89,6 @@ false
 pyenv-virtualenv: activate venv
 export PYENV_VERSION="venv";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
@@ -117,7 +113,6 @@ EOS
   assert_output <<EOS
 false
 pyenv-virtualenv: activate venv
-set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing not work for fish.
 EOS
@@ -147,7 +142,6 @@ false
 pyenv-virtualenv: activate venv
 setenv PYENV_VERSION "venv";
 setenv PYENV_ACTIVATE_SHELL 1;
-set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv";
 pyenv-virtualenv: prompt changing not work for fish.
 EOS
@@ -170,7 +164,6 @@ false
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
@@ -200,7 +193,6 @@ false
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";
@@ -225,7 +217,6 @@ false
 pyenv-virtualenv: activate venv27
 setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
-set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing not work for fish.
 EOS
@@ -253,7 +244,6 @@ false
 pyenv-virtualenv: activate venv27
 setenv PYENV_VERSION "venv27";
 setenv PYENV_ACTIVATE_SHELL 1;
-set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing not work for fish.
 EOS
@@ -365,7 +355,6 @@ false
 pyenv-virtualenv: activate venv27
 export PYENV_VERSION="venv27:2.7.10";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv27";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
 export _OLD_VIRTUAL_PS1="\${PS1}";

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -7,7 +7,6 @@ setup() {
   export PYENV_ROOT="${TMP}/pyenv"
   unset PYENV_VERSION
   unset PYENV_ACTIVATE_SHELL
-  unset PYENV_DEACTIVATE
   unset VIRTUAL_ENV
   unset CONDA_DEFAULT_ENV
   unset PYTHONHOME
@@ -36,7 +35,6 @@ setup() {
   assert_output <<EOS
 false
 pyenv-virtualenv: activate anaconda-2.3.0
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0";
 export CONDA_DEFAULT_ENV="root";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
@@ -63,7 +61,6 @@ EOS
   assert_output <<EOS
 false
 pyenv-virtualenv: activate anaconda-2.3.0
-set -e PYENV_DEACTIVATE;
 setenv VIRTUAL_ENV "${TMP}/pyenv/versions/anaconda-2.3.0";
 setenv CONDA_DEFAULT_ENV "root";
 pyenv-virtualenv: prompt changing not work for fish.
@@ -89,7 +86,6 @@ false
 pyenv-virtualenv: activate miniconda-3.9.1
 export PYENV_VERSION="miniconda-3.9.1";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1";
 export CONDA_DEFAULT_ENV="root";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
@@ -116,7 +112,6 @@ EOS
   assert_output <<EOS
 false
 pyenv-virtualenv: activate anaconda-2.3.0/envs/foo
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 export CONDA_DEFAULT_ENV="foo";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
@@ -144,7 +139,6 @@ false
 pyenv-virtualenv: activate miniconda-3.9.1/envs/bar
 export PYENV_VERSION="miniconda-3.9.1/envs/bar";
 export PYENV_ACTIVATE_SHELL=1;
-unset PYENV_DEACTIVATE;
 export VIRTUAL_ENV="${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar";
 export CONDA_DEFAULT_ENV="bar";
 pyenv-virtualenv: prompt changing will be removed from future release. configure \`export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -6,7 +6,6 @@ setup() {
   export PYENV_ROOT="${TMP}/pyenv"
   unset PYENV_VERSION
   unset PYENV_ACTIVATE_SHELL
-  unset PYENV_DEACTIVATE
   unset VIRTUAL_ENV
   unset CONDA_DEFAULT_ENV
   unset PYTHONHOME
@@ -29,7 +28,6 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0";
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
@@ -63,7 +61,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0
-setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/anaconda-2.3.0";
 set -e VIRTUAL_ENV;
 set -e CONDA_DEFAULT_ENV;
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
@@ -93,7 +90,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate anaconda-2.3.0/envs/foo
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo";
 unset VIRTUAL_ENV;
 unset CONDA_DEFAULT_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then

--- a/test/deactivate.bats
+++ b/test/deactivate.bats
@@ -6,7 +6,6 @@ setup() {
   export PYENV_ROOT="${TMP}/pyenv"
   unset PYENV_VERSION
   unset PYENV_ACTIVATE_SHELL
-  unset PYENV_DEACTIVATE
   unset VIRTUAL_ENV
   unset CONDA_DEFAULT_ENV
   unset PYTHONHOME
@@ -18,6 +17,7 @@ setup() {
 }
 
 @test "deactivate virtualenv" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -26,7 +26,6 @@ setup() {
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
@@ -47,6 +46,7 @@ EOS
 }
 
 @test "deactivate virtualenv (verbose)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -55,7 +55,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
@@ -76,6 +75,7 @@ EOS
 }
 
 @test "deactivate virtualenv (quiet)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -84,7 +84,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
@@ -105,6 +104,7 @@ EOS
 }
 
 @test "deactivate virtualenv (with shell activation)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
@@ -115,7 +115,6 @@ EOS
 pyenv-virtualenv: deactivate venv
 unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
@@ -136,6 +135,7 @@ EOS
 }
 
 @test "deactivate virtualenv (with shell activation) (quiet)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
@@ -146,7 +146,6 @@ EOS
 pyenv-virtualenv: deactivate venv
 unset PYENV_VERSION;
 unset PYENV_ACTIVATE_SHELL;
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
@@ -167,6 +166,7 @@ EOS
 }
 
 @test "deactivate virtualenv which has been activated manually" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -175,7 +175,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-export PYENV_DEACTIVATE="${PYENV_ROOT}/versions/venv";
 unset VIRTUAL_ENV;
 if [ -n "\${_OLD_VIRTUAL_PATH}" ]; then
   export PATH="\${_OLD_VIRTUAL_PATH}";
@@ -196,6 +195,7 @@ EOS
 }
 
 @test "deactivate virtualenv (fish)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -204,7 +204,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
   setenv PATH "\$_OLD_VIRTUAL_PATH";
@@ -221,6 +220,7 @@ EOS
 }
 
 @test "deactivate virtualenv (fish) (quiet)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -229,7 +229,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
   setenv PATH "\$_OLD_VIRTUAL_PATH";
@@ -246,6 +245,7 @@ EOS
 }
 
 @test "deactivate virtualenv (fish) (with shell activation)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
@@ -256,7 +256,6 @@ EOS
 pyenv-virtualenv: deactivate venv
 set -e PYENV_VERSION;
 set -e PYENV_ACTIVATE_SHELL;
-setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
   setenv PATH "\$_OLD_VIRTUAL_PATH";
@@ -273,6 +272,7 @@ EOS
 }
 
 @test "deactivate virtualenv (fish) (with shell activation) (quiet)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=1
 
@@ -283,7 +283,6 @@ EOS
 pyenv-virtualenv: deactivate venv
 set -e PYENV_VERSION;
 set -e PYENV_ACTIVATE_SHELL;
-setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
   setenv PATH "\$_OLD_VIRTUAL_PATH";
@@ -300,6 +299,7 @@ EOS
 }
 
 @test "deactivate virtualenv which has been activated manually (fish)" {
+  export PYENV_VIRTUALENV_INIT=1
   export VIRTUAL_ENV="${PYENV_ROOT}/versions/venv"
   export PYENV_ACTIVATE_SHELL=
 
@@ -308,7 +308,6 @@ EOS
   assert_success
   assert_output <<EOS
 pyenv-virtualenv: deactivate venv
-setenv PYENV_DEACTIVATE "${PYENV_ROOT}/versions/venv";
 set -e VIRTUAL_ENV;
 if [ -n "\$_OLD_VIRTUAL_PATH" ];
   setenv PATH "\$_OLD_VIRTUAL_PATH";

--- a/test/version.bats
+++ b/test/version.bats
@@ -28,7 +28,6 @@ setup() {
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.4.1'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.4.1'"
   stub pyenv-which "pyvenv : echo \"${PYENV_ROOT}/versions/3.4.1/bin/pyvenv\""
-  stub pyenv-root "echo \"${PYENV_ROOT}\""
 
   remove_executable "3.4.1" "virtualenv"
   create_executable "3.4.1" "pyvenv"
@@ -39,5 +38,4 @@ setup() {
   assert_output "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (pyvenv 3.4.1)"
 
   unstub pyenv-prefix
-  unstub pyenv-root
 }


### PR DESCRIPTION
This will change existing behaviour a little. Though removing error prone feature would be beneficial than corner cases.

If a user wants to activate/deactivate manually, I'd recommend s?he to remove `eval "$(pyenv virtualenv-init -)"` from his/her shell configuration.

@blueyed can you give a look on this?