### PR TITLE
Use `conda create` to create virtual environment if `conda` is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ command is not available.
 Because Anaconda and Miniconda may install standard commands (e.g. `curl`, `openssl`, `sqlite3`, etc.) into their prefix,
 we'd recommend you to install [pyenv-which-ext](https://github.com/yyuu/pyenv-which-ext).
 
-You can manage `conda` environments by `conda env` as same manner as standard Anaconda/Miniconda installations.
+You can manage `conda` environments by `conda create` as same manner as standard Anaconda/Miniconda installations.
 To use those environments, you can use `pyenv activate` and `pyenv deactivate`.
 
 ```
@@ -172,13 +172,27 @@ $ conda env list
 #
 myenv                    /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv
 root                  *  /home/yyuu/.pyenv/versions/miniconda3-3.9.1
-$ pyenv activate myenv
+$ pyenv activate miniconda3-3.9.1/envs/myenv
 discarding /home/yyuu/.pyenv/versions/miniconda3-3.9.1/bin from PATH
 prepending /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv/bin to PATH
 $ python --version
 Python 3.4.3 :: Continuum Analytics, Inc.
 $ pyenv deactivate
 discarding /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv/bin from PATH
+```
+
+If `conda` is available, `pyenv virtualenv` will use it to create environment by `conda create`.
+
+```
+$ pyenv version
+miniconda3-3.9.1 (set by /home/yyuu/.pyenv/version)
+$ pyenv virtualenv myenv2
+$ conda env list
+# conda environments:
+#
+myenv                    /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv
+myenv                    /home/yyuu/.pyenv/versions/miniconda3-3.9.1/envs/myenv2
+root                  *  /home/yyuu/.pyenv/versions/miniconda3-3.9.1
 ```
 
 You can use version like `miniconda3-3.9.1/envs/myenv` to specify `conda` environment as a version in pyenv.

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -103,45 +103,57 @@ http_get_wget() {
 version() {
   detect_venv
   local version
-  if [ -n "$USE_PYVENV" ]; then
-    version="$(pyenv-which pyvenv 2>/dev/null || true)"
-    version="${version#${PYENV_ROOT}/versions/}"
-    version="${version%/bin/pyvenv}"
-    echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (pyvenv ${version:-unknown})"
+  if [ -n "${USE_CONDA}" ]; then
+    version="$(pyenv-exec conda --version 2>/dev/null || true)"
+    echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (conda ${version:-unknown})"
   else
-    version="$(venv --version 2>/dev/null || true)"
-    echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (virtualenv ${version:-unknown})"
+    if [ -n "$USE_PYVENV" ]; then
+      version="$(pyenv-which pyvenv 2>/dev/null || true)"
+      version="${version#${PYENV_ROOT}/versions/}"
+      version="${version%/bin/pyvenv}"
+      echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (pyvenv ${version:-unknown})"
+    else
+      version="$(pyenv-exec virtualenv --version 2>/dev/null || true)"
+      echo "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (virtualenv ${version:-unknown})"
+    fi
   fi
 }
 
 usage() {
   # We can remove the sed fallback once pyenv 0.2.0 is widely available.
   pyenv-help virtualenv 2>/dev/null || sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$0"
-  venv --help 2>/dev/null || true
+  if [ -n "${USE_CONDA}" ]; then
+    pyenv-exec conda create --help 2>/dev/null || true
+  else
+    if [ -n "${USE_PYVENV}" ]; then
+      pyenv-exec pyvenv --help 2>/dev/null || true
+    else
+      pyenv-exec virtualenv --help 2>/dev/null || true
+    fi
+  fi
   [ -z "$1" ] || exit "$1"
 }
 
 detect_venv() {
   # Check the existence of executables as a workaround for the issue with pyenv-which-ext
   # https://github.com/yyuu/pyenv-virtualenv/issues/26
-  if [ -x "$(pyenv-prefix)/bin/virtualenv" ]; then
-    HAS_VIRTUALENV=1
-  fi
-  if [ -x "$(pyenv-prefix)/bin/pyvenv" ]; then
-    HAS_PYVENV=1
+  if [ -x "$(pyenv-prefix)/bin/conda" ]; then
+    HAS_CONDA=1
+  else
+    if [ -x "$(pyenv-prefix)/bin/virtualenv" ]; then
+      HAS_VIRTUALENV=1
+    fi
+    if [ -x "$(pyenv-prefix)/bin/pyvenv" ]; then
+      HAS_PYVENV=1
+    fi
   fi
   # Use pyvenv only if there is pyvenv, virtualenv is not installed, and `-p` not given
-  if [ -n "${HAS_PYVENV}" ] && [ -z "${HAS_VIRTUALENV}" ] && [ -z "${VIRTUALENV_PYTHON}" ]; then
-    USE_PYVENV=1
-  fi
-}
-
-venv() {
-  local args=("$@")
-  if [ -n "${USE_PYVENV}" ]; then
-    pyenv-exec pyvenv "${args[@]}"
+  if [ -n "${HAS_CONDA}" ]; then
+    USE_CONDA=1
   else
-    pyenv-exec virtualenv "${args[@]}"
+    if [ -n "${HAS_PYVENV}" ] && [ -z "${HAS_VIRTUALENV}" ] && [ -z "${VIRTUALENV_PYTHON}" ]; then
+      USE_PYVENV=1
+    fi
   fi
 }
 
@@ -296,12 +308,13 @@ fi
 export PYENV_VERSION="${VERSION_NAME}"
 
 # Source version must exist before creating virtualenv.
-if ! pyenv-prefix 1>/dev/null 2>&1; then
+PREFIX="$(pyenv-prefix 2>/dev/null || true)"
+if [ ! -d "${PREFIX}" ]; then
   echo "pyenv-virtualenv: \`${PYENV_VERSION}' is not installed in pyenv." 1>&2
   exit 1
 fi
 
-if pyenv-virtualenv-prefix "${VERSION_NAME}" 1>/dev/null 2>&1; then
+if [[ "${PREFIX}" != "${PREFIX%/envs/*}" ]]; then
   echo "pyenv-virtualenv: nested virtualenv is not supported." 1>&2
   exit 1
 fi
@@ -333,6 +346,7 @@ fi
 
 unset HAS_VIRTUALENV
 unset HAS_PYVENV
+unset USE_CONDA
 unset USE_PYVENV
 detect_venv
 
@@ -350,37 +364,41 @@ if [ -n "$UPGRADE" ]; then
   fi
 fi
 
-if [ -n "${USE_PYVENV}" ]; then
-  # Unset some arguments not supported by pyvenv
-  unset QUIET
-  unset VERBOSE
-  if [ -n "${VIRTUALENV_PYTHON}" ]; then
-    echo "pyenv-virtualenv: \`--python=${VIRTUALENV_PYTHON}' is not supported by pyvenv." 1>&2
-    exit 1
-  fi
+if [ -n "${USE_CONDA}" ]; then
+  :
 else
-  if [ -n "${VIRTUALENV_PYTHON}" ]; then
-    if [[ "${VIRTUALENV_PYTHON}" == "${VIRTUALENV_PYTHON##*/}" ]] || [[ "${VIRTUALENV_PYTHON}" == "${PYENV_ROOT}/shims/"* ]]; then
-      python="$(pyenv-which "${VIRTUALENV_PYTHON##*/}" 2>/dev/null || true)"
-      if [ -x "${python}" ]; then
-        VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="--python=${python}"
-      else
-        python="$(PYENV_VERSION="$(pyenv-whence "${VIRTUALENV_PYTHON##*/}" 2>/dev/null | tail -n 1 || true)" pyenv-which "${VIRTUALENV_PYTHON##*/}" 2>/dev/null || true)"
+  if [ -n "${USE_PYVENV}" ]; then
+    # Unset some arguments not supported by pyvenv
+    unset QUIET
+    unset VERBOSE
+    if [ -n "${VIRTUALENV_PYTHON}" ]; then
+      echo "pyenv-virtualenv: \`--python=${VIRTUALENV_PYTHON}' is not supported by pyvenv." 1>&2
+      exit 1
+    fi
+  else
+    if [ -n "${VIRTUALENV_PYTHON}" ]; then
+      if [[ "${VIRTUALENV_PYTHON}" == "${VIRTUALENV_PYTHON##*/}" ]] || [[ "${VIRTUALENV_PYTHON}" == "${PYENV_ROOT}/shims/"* ]]; then
+        python="$(pyenv-which "${VIRTUALENV_PYTHON##*/}" 2>/dev/null || true)"
         if [ -x "${python}" ]; then
           VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="--python=${python}"
         else
-          echo "pyenv-virtualenv: \`${VIRTUALENV_PYTHON##*/}' is not installed in pyenv." 1>&2
-          exit 1
+          python="$(PYENV_VERSION="$(pyenv-whence "${VIRTUALENV_PYTHON##*/}" 2>/dev/null | tail -n 1 || true)" pyenv-which "${VIRTUALENV_PYTHON##*/}" 2>/dev/null || true)"
+          if [ -x "${python}" ]; then
+            VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="--python=${python}"
+          else
+            echo "pyenv-virtualenv: \`${VIRTUALENV_PYTHON##*/}' is not installed in pyenv." 1>&2
+            exit 1
+          fi
         fi
+      else
+        VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="--python=${VIRTUALENV_PYTHON}"
       fi
-    else
-      VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="--python=${VIRTUALENV_PYTHON}"
     fi
-  fi
-  if [ -z "${HAS_VIRTUALENV}" ]; then
-    VIRTUALENV_VERSION="==${VIRTUALENV_VERSION}"
-    pyenv-exec pip install $QUIET $VERBOSE "virtualenv${VIRTUALENV_VERSION%==}"
-    HAS_VIRTUALENV=1
+    if [ -z "${HAS_VIRTUALENV}" ]; then
+      VIRTUALENV_VERSION="==${VIRTUALENV_VERSION}"
+      pyenv-exec pip install $QUIET $VERBOSE "virtualenv${VIRTUALENV_VERSION%==}"
+      HAS_VIRTUALENV=1
+    fi
   fi
 fi
 
@@ -456,7 +474,15 @@ STATUS=0
 # Change to cache directory to reuse them between invocations.
 mkdir -p "${PYENV_VIRTUALENV_CACHE_PATH}"
 cd "${PYENV_VIRTUALENV_CACHE_PATH}"
-venv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
+if [ -n "${USE_CONDA}" ]; then
+  pyenv-exec conda create $QUIET $VERBOSE --name "${VIRTUALENV_PATH##*/}" --yes "${VIRTUALENV_OPTIONS[@]}" python || STATUS="$?"
+else
+  if [ -n "${USE_PYVENV}" ]; then
+    pyenv-exec pyvenv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
+  else
+    pyenv-exec virtualenv $QUIET $VERBOSE "${VIRTUALENV_OPTIONS[@]}" "${VIRTUALENV_PATH}" || STATUS="$?"
+  fi
+fi
 
 ## Create symlink in the `versions` directory for backward compatibility
 if [ -d "${VIRTUALENV_PATH}" ] && [ -n "${COMPAT_VIRTUALENV_PATH}" ]; then

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -137,13 +137,14 @@ usage() {
 detect_venv() {
   # Check the existence of executables as a workaround for the issue with pyenv-which-ext
   # https://github.com/yyuu/pyenv-virtualenv/issues/26
-  if [ -x "$(pyenv-prefix)/bin/conda" ]; then
+  local prefix="$(pyenv-prefix)"
+  if [ -x "${prefix}/bin/conda" ]; then
     HAS_CONDA=1
   else
-    if [ -x "$(pyenv-prefix)/bin/virtualenv" ]; then
+    if [ -x "${prefix}/bin/virtualenv" ]; then
       HAS_VIRTUALENV=1
     fi
-    if [ -x "$(pyenv-prefix)/bin/pyvenv" ]; then
+    if [ -x "${prefix}/bin/pyvenv" ]; then
       HAS_PYVENV=1
     fi
   fi

--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -365,7 +365,14 @@ if [ -n "$UPGRADE" ]; then
 fi
 
 if [ -n "${USE_CONDA}" ]; then
-  :
+  # e.g. `conda create -n py35 python=3.5 anaconda`
+  if [ -n "${VIRTUALENV_PYTHON}" ]; then
+    VIRTUALENV_PYTHON="${VIRTUALENV_PYTHON##*/}"
+    VIRTUALENV_PYTHON="${VIRTUALENV_PYTHON#python}"
+    if [ -n "${VIRTUALENV_PYTHON}" ]; then
+      VIRTUALENV_OPTIONS[${#VIRTUALENV_OPTIONS[*]}]="python=${VIRTUALENV_PYTHON}"
+    fi
+  fi
 else
   if [ -n "${USE_PYVENV}" ]; then
     # Unset some arguments not supported by pyvenv

--- a/test/conda-activate.bats
+++ b/test/conda-activate.bats
@@ -20,7 +20,7 @@ setup() {
 @test "activate conda root from current version" {
   export PYENV_VIRTUALENV_INIT=1
 
-  create_conda "anaconda-2.3.0"
+  setup_conda "anaconda-2.3.0"
   stub pyenv-version-name "echo anaconda-2.3.0"
   stub pyenv-virtualenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
   stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
@@ -43,12 +43,13 @@ EOS
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
   unstub pyenv-sh-deactivate
+  teardown_conda "anaconda-2.3.0"
 }
 
 @test "activate conda root from current version (fish)" {
   export PYENV_VIRTUALENV_INIT=1
 
-  create_conda "anaconda-2.3.0"
+  setup_conda "anaconda-2.3.0"
   stub pyenv-version-name "echo anaconda-2.3.0"
   stub pyenv-virtualenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
   stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
@@ -69,13 +70,14 @@ EOS
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
   unstub pyenv-sh-deactivate
+  teardown_conda "anaconda-2.3.0"
 }
 
 @test "activate conda root from command-line argument" {
   export PYENV_VIRTUALENV_INIT=1
 
-  create_conda "anaconda-2.3.0"
-  create_conda "miniconda-3.9.1"
+  setup_conda "anaconda-2.3.0"
+  setup_conda "miniconda-3.9.1"
   stub pyenv-virtualenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
   stub pyenv-prefix "miniconda-3.9.1 : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
   stub pyenv-sh-deactivate "--force --quiet : echo deactivated"
@@ -98,12 +100,14 @@ EOS
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
   unstub pyenv-sh-deactivate
+  teardown_conda "anaconda-2.3.0"
+  teardown_conda "miniconda-3.9.1"
 }
 
 @test "activate conda env from current version" {
   export PYENV_VIRTUALENV_INIT=1
 
-  create_conda "anaconda-2.3.0" "foo"
+  setup_conda "anaconda-2.3.0" "foo"
   stub pyenv-version-name "echo anaconda-2.3.0/envs/foo"
   stub pyenv-virtualenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
   stub pyenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
@@ -126,13 +130,14 @@ EOS
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
   unstub pyenv-sh-deactivate
+  teardown_conda "anaconda-2.3.0" "foo"
 }
 
 @test "activate conda env from command-line argument" {
   export PYENV_VIRTUALENV_INIT=1
 
-  create_conda "anaconda-2.3.0" "foo"
-  create_conda "miniconda-3.9.1" "bar"
+  setup_conda "anaconda-2.3.0" "foo"
+  setup_conda "miniconda-3.9.1" "bar"
   stub pyenv-virtualenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1\""
   stub pyenv-prefix "miniconda-3.9.1/envs/bar : echo \"${PYENV_ROOT}/versions/miniconda-3.9.1/envs/bar\""
   stub pyenv-sh-deactivate "--force --quiet : echo deactivated"
@@ -155,4 +160,6 @@ EOS
   unstub pyenv-virtualenv-prefix
   unstub pyenv-prefix
   unstub pyenv-sh-deactivate
+  teardown_conda "anaconda-2.3.0" "foo"
+  teardown_conda "miniconda-3.9.1" "bar"
 }

--- a/test/conda-deactivate.bats
+++ b/test/conda-deactivate.bats
@@ -21,7 +21,7 @@ setup() {
   export PYENV_ACTIVATE_SHELL=
   export CONDA_DEFAULT_ENV="root"
 
-  create_conda "anaconda-2.3.0"
+  setup_conda "anaconda-2.3.0"
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate
 
@@ -46,6 +46,8 @@ if declare -f deactivate 1>/dev/null 2>&1; then
   unset -f deactivate;
 fi;
 EOS
+
+  teardown_conda "anaconda-2.3.0"
 }
 
 @test "deactivate conda root (fish)" {
@@ -53,8 +55,7 @@ EOS
   export PYENV_ACTIVATE_SHELL=
   export CONDA_DEFAULT_ENV="root"
 
-
-  create_conda "anaconda-2.3.0"
+  setup_conda "anaconda-2.3.0"
 
   PYENV_SHELL="fish" run pyenv-sh-deactivate
 
@@ -75,6 +76,8 @@ if functions -g deactivate;
   functions -e deactivate;
 end;
 EOS
+
+  teardown_conda "anaconda-2.3.0"
 }
 
 @test "deactivate conda env" {
@@ -82,8 +85,7 @@ EOS
   export PYENV_ACTIVATE_SHELL=
   export CONDA_DEFAULT_ENV="foo"
 
-
-  create_conda "anaconda-2.3.0" "foo"
+  setup_conda "anaconda-2.3.0" "foo"
 
   PYENV_SHELL="bash" run pyenv-sh-deactivate
 
@@ -108,4 +110,6 @@ if declare -f deactivate 1>/dev/null 2>&1; then
   unset -f deactivate;
 fi;
 EOS
+
+  teardown_conda "anaconda-2.3.0" "foo"
 }

--- a/test/conda-prefix.bats
+++ b/test/conda-prefix.bats
@@ -7,8 +7,7 @@ setup() {
 }
 
 @test "display conda root" {
-  create_conda "anaconda-2.3.0"
-
+  setup_conda "anaconda-2.3.0"
   stub pyenv-version-name "echo anaconda-2.3.0"
   stub pyenv-prefix "anaconda-2.3.0 : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0\""
 
@@ -21,11 +20,11 @@ OUT
 
   unstub pyenv-version-name
   unstub pyenv-prefix
+  teardown_conda "anaconda-2.3.0"
 }
 
 @test "display conda env" {
-  create_conda "anaconda-2.3.0" "foo"
-
+  setup_conda "anaconda-2.3.0" "foo"
   stub pyenv-version-name "echo anaconda-2.3.0/envs/foo"
   stub pyenv-prefix "anaconda-2.3.0/envs/foo : echo \"${PYENV_ROOT}/versions/anaconda-2.3.0/envs/foo\""
 
@@ -38,4 +37,5 @@ OUT
 
   unstub pyenv-version-name
   unstub pyenv-prefix
+  teardown_conda "anaconda-2.3.0" "foo"
 }

--- a/test/conda.bats
+++ b/test/conda.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  export PYENV_ROOT="${TMP}/pyenv"
+}
+
+stub_pyenv() {
+  stub pyenv-version-name "echo \${PYENV_VERSION}"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-hooks "virtualenv : echo"
+  stub pyenv-rehash " : echo rehashed"
+}
+
+unstub_pyenv() {
+  unstub pyenv-version-name
+  unstub pyenv-prefix
+  unstub pyenv-hooks
+  unstub pyenv-rehash
+}
+
+@test "create virtualenv by conda create" {
+  export PYENV_VERSION="miniconda3-3.16.0"
+  setup_conda "${PYENV_VERSION}"
+  stub_pyenv "${PYENV_VERSION}"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "conda * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "python -s -m ensurepip : true"
+
+  run pyenv-virtualenv venv
+
+  assert_success
+  assert_output <<OUT
+PYENV_VERSION=miniconda3-3.16.0 conda create --name venv --yes python
+rehashed
+OUT
+
+  unstub_pyenv
+  unstub pyenv-exec
+  teardown_pyvenv "miniconda3-3.16.0"
+}
+
+@test "create virtualenv by conda create with -p" {
+  export PYENV_VERSION="miniconda3-3.16.0"
+  setup_conda "${PYENV_VERSION}"
+  stub_pyenv "${PYENV_VERSION}"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "conda * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "python -s -m ensurepip : true"
+
+  run pyenv-virtualenv -p python3.5 venv
+
+  assert_success
+  assert_output <<OUT
+PYENV_VERSION=miniconda3-3.16.0 conda create --name venv --yes python=3.5 python
+rehashed
+OUT
+
+  unstub_pyenv
+  unstub pyenv-exec
+  teardown_pyvenv "miniconda3-3.16.0"
+}
+
+@test "create virtualenv by conda create with --python" {
+  export PYENV_VERSION="miniconda3-3.16.0"
+  setup_conda "${PYENV_VERSION}"
+  stub_pyenv "${PYENV_VERSION}"
+  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
+  stub pyenv-exec "conda * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
+  stub pyenv-exec "python -s -m ensurepip : true"
+
+  run pyenv-virtualenv --python=python3.5 venv
+
+  assert_success
+  assert_output <<OUT
+PYENV_VERSION=miniconda3-3.16.0 conda create --name venv --yes python=3.5 python
+rehashed
+OUT
+
+  unstub_pyenv
+  unstub pyenv-exec
+  teardown_pyvenv "miniconda3-3.16.0"
+}

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -13,15 +13,14 @@ setup() {
 before_virtualenv 'echo before: \$VIRTUALENV_PATH'
 after_virtualenv 'echo after: \$STATUS'
 OUT
-  stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.2.1'"
+  setup_version "3.2.1"
+  create_executable "3.2.1" "virtualenv"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.2.1'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.2.1'"
   stub pyenv-hooks "virtualenv : echo '$HOOK_PATH'/virtualenv.bash"
   stub pyenv-exec "echo PYENV_VERSION=3.2.1 \"\$@\""
+  stub pyenv-exec "echo PYENV_VERSION=3.2.1 \"\$@\""
   stub pyenv-rehash "echo rehashed"
-
-  create_executable "3.2.1" "virtualenv"
-  remove_executable "3.2.1" "pyvenv"
 
   run pyenv-virtualenv "3.2.1" venv
 
@@ -29,7 +28,14 @@ OUT
   assert_output <<-OUT
 before: ${PYENV_ROOT}/versions/3.2.1/envs/venv
 PYENV_VERSION=3.2.1 virtualenv ${PYENV_ROOT}/versions/3.2.1/envs/venv
+PYENV_VERSION=3.2.1 python -s -m ensurepip
 after: 0
 rehashed
 OUT
+
+  unstub pyenv-prefix
+  unstub pyenv-hooks
+  unstub pyenv-exec
+  unstub pyenv-rehash
+  teardown_version "3.2.1"
 }

--- a/test/pip.bats
+++ b/test/pip.bats
@@ -24,8 +24,6 @@ unstub_pyenv() {
   export PYENV_VERSION="3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.4.1/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.4.1/envs/venv/bin/pip"
 
@@ -49,8 +47,6 @@ OUT
 @test "install pip without using ensurepip" {
   export PYENV_VERSION="3.3.5"
   stub_pyenv "${PYENV_VERSION}"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.3.5/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : false"

--- a/test/pip.bats
+++ b/test/pip.bats
@@ -22,13 +22,11 @@ unstub_pyenv() {
 
 @test "install pip with ensurepip" {
   export PYENV_VERSION="3.4.1"
+  setup_pyvenv "3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.4.1/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.4.1/envs/venv/bin/pip"
-
-  remove_executable "3.4.1" "virtualenv"
-  create_executable "3.4.1" "pyvenv"
 
   run pyenv-virtualenv venv
 
@@ -42,19 +40,18 @@ OUT
 
   unstub_pyenv
   unstub pyenv-exec
+  teardown_pyvenv "3.4.1"
 }
 
 @test "install pip without using ensurepip" {
   export PYENV_VERSION="3.3.5"
+  setup_pyvenv "3.3.5"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";mkdir -p \${PYENV_ROOT}/versions/3.3.5/envs/venv/bin"
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\";touch \${PYENV_ROOT}/versions/3.3.5/envs/venv/bin/pip"
   stub curl true
-
-  remove_executable "3.3.5" "virtualenv"
-  create_executable "3.3.5" "pyvenv"
 
   run pyenv-virtualenv venv
 
@@ -69,4 +66,5 @@ OUT
 
   unstub_pyenv
   unstub pyenv-exec
+  teardown_pyvenv "3.3.5"
 }

--- a/test/python.bats
+++ b/test/python.bats
@@ -5,8 +5,8 @@ load test_helper
 setup() {
   export PYENV_ROOT="${TMP}/pyenv"
   export PYENV_VERSION="2.7.8"
-  create_executable "${PYENV_VERSION}" "virtualenv"
-  remove_executable "${PYENV_VERSION}" "pyvenv"
+  setup_version "2.7.8"
+  create_executable "2.7.8" "virtualenv"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
@@ -22,6 +22,7 @@ teardown() {
   unstub pyenv-prefix
   unstub pyenv-hooks
   unstub pyenv-rehash
+  teardown_version "2.7.8"
   rm -fr "$TMP"/*
 }
 

--- a/test/pyvenv.bats
+++ b/test/pyvenv.bats
@@ -24,13 +24,13 @@ unstub_pyenv() {
   export PYENV_VERSION="3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
+  create_executable "3.4.1" "python"
   remove_executable "3.4.1" "virtualenv"
   create_executable "3.4.1" "pyvenv"
+  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv venv
 
@@ -48,13 +48,13 @@ OUT
   export PYENV_VERSION="3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
+  create_executable "3.4.1" "python"
   create_executable "3.4.1" "virtualenv"
   create_executable "3.4.1" "pyvenv"
+  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv venv
 
@@ -72,16 +72,16 @@ OUT
   export PYENV_VERSION="3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
 
+  create_executable "3.2.1" "python"
   remove_executable "3.2.1" "virtualenv"
   remove_executable "3.2.1" "pyvenv"
+  remove_executable "3.2.1" "conda"
 
   run pyenv-virtualenv venv
 
@@ -102,14 +102,14 @@ OUT
   export PYENV_VERSION="3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
+  create_executable "3.4.1" "python"
   remove_executable "3.4.1" "virtualenv"
   create_executable "3.4.1" "pyvenv"
+  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv -p ${TMP}/python3 venv
 
@@ -128,14 +128,14 @@ OUT
   export PYENV_VERSION="3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
 
+  create_executable "3.4.1" "python"
   remove_executable "3.4.1" "virtualenv"
   create_executable "3.4.1" "pyvenv"
+  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv --python=${TMP}/python3 venv
 
@@ -154,16 +154,16 @@ OUT
   export PYENV_VERSION="3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PIP_REQUIRE_VENV=\${PIP_REQUIRE_VENV} PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "virtualenv * : echo PIP_REQUIRE_VENV=\${PIP_REQUIRE_VENV} PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
 
+  create_executable "3.2.1" "python"
   remove_executable "3.2.1" "virtualenv"
   remove_executable "3.2.1" "pyvenv"
+  remove_executable "3.2.1" "conda"
 
   PIP_REQUIRE_VENV="true" run pyenv-virtualenv venv
 

--- a/test/pyvenv.bats
+++ b/test/pyvenv.bats
@@ -22,15 +22,11 @@ unstub_pyenv() {
 
 @test "use pyvenv if virtualenv is not available" {
   export PYENV_VERSION="3.4.1"
+  setup_pyvenv "3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pyvenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
-
-  create_executable "3.4.1" "python"
-  remove_executable "3.4.1" "virtualenv"
-  create_executable "3.4.1" "pyvenv"
-  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv venv
 
@@ -42,19 +38,17 @@ OUT
 
   unstub_pyenv
   unstub pyenv-exec
+  teardown_pyvenv "3.4.1"
 }
 
 @test "not use pyvenv if virtualenv is available" {
   export PYENV_VERSION="3.4.1"
+  setup_pyvenv "3.4.1"
+  create_executable "3.4.1" "virtualenv"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
-
-  create_executable "3.4.1" "python"
-  create_executable "3.4.1" "virtualenv"
-  create_executable "3.4.1" "pyvenv"
-  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv venv
 
@@ -66,10 +60,12 @@ OUT
 
   unstub_pyenv
   unstub pyenv-exec
+  teardown_pyvenv "3.4.1"
 }
 
 @test "install virtualenv if pyvenv is not avaialble" {
   export PYENV_VERSION="3.2.1"
+  setup_version "3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
@@ -77,11 +73,6 @@ OUT
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
-
-  create_executable "3.2.1" "python"
-  remove_executable "3.2.1" "virtualenv"
-  remove_executable "3.2.1" "pyvenv"
-  remove_executable "3.2.1" "conda"
 
   run pyenv-virtualenv venv
 
@@ -96,20 +87,17 @@ OUT
   unstub_pyenv
   unstub pyenv-exec
   unstub curl
+  teardown_version "3.2.1"
 }
 
 @test "install virtualenv if -p has given" {
   export PYENV_VERSION="3.4.1"
+  setup_pyvenv "3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
-
-  create_executable "3.4.1" "python"
-  remove_executable "3.4.1" "virtualenv"
-  create_executable "3.4.1" "pyvenv"
-  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv -p ${TMP}/python3 venv
 
@@ -122,20 +110,17 @@ OUT
 
   unstub_pyenv
   unstub pyenv-exec
+  teardown_pyvenv "3.4.1"
 }
 
 @test "install virtualenv if --python has given" {
   export PYENV_VERSION="3.4.1"
+  setup_pyvenv "3.4.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "virtualenv * : echo PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
   stub pyenv-exec "python -s -m ensurepip : true"
-
-  create_executable "3.4.1" "python"
-  remove_executable "3.4.1" "virtualenv"
-  create_executable "3.4.1" "pyvenv"
-  remove_executable "3.4.1" "conda"
 
   run pyenv-virtualenv --python=${TMP}/python3 venv
 
@@ -148,10 +133,12 @@ OUT
 
   unstub_pyenv
   unstub pyenv-exec
+  teardown_pyvenv "3.4.1"
 }
 
 @test "install virtualenv with unsetting troublesome pip options" {
   export PYENV_VERSION="3.2.1"
+  setup_version "3.2.1"
   stub_pyenv "${PYENV_VERSION}"
   stub pyenv-prefix " : echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-exec "pip install virtualenv : echo PIP_REQUIRE_VENV=\${PIP_REQUIRE_VENV} PYENV_VERSION=\${PYENV_VERSION} \"\$@\""
@@ -159,11 +146,6 @@ OUT
   stub pyenv-exec "python -s -m ensurepip : false"
   stub pyenv-exec "python -s */get-pip.py : true"
   stub curl true
-
-  create_executable "3.2.1" "python"
-  remove_executable "3.2.1" "virtualenv"
-  remove_executable "3.2.1" "pyvenv"
-  remove_executable "3.2.1" "conda"
 
   PIP_REQUIRE_VENV="true" run pyenv-virtualenv venv
 
@@ -178,4 +160,5 @@ OUT
   unstub_pyenv
   unstub pyenv-exec
   unstub curl
+  teardown_version "3.2.1"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -117,22 +117,56 @@ remove_executable() {
   rm -f "${PYENV_ROOT}/versions/$1/bin/$2"
 }
 
-create_conda() {
-  local version="$1"
+setup_version() {
+  create_executable "$1" "python"
+  remove_executable "$1" "activate"
+  remove_executable "$1" "pyvenv"
+  remove_executable "$1" "conda"
+}
+
+teardown_version() {
+  rm -fr "${PYENV_ROOT}/versions/$1"
+}
+
+setup_virtualenv() {
+  create_executable "$1" "python"
+  create_executable "$1" "activate"
+  remove_executable "$1" "pyvenv"
+  remove_executable "$1" "conda"
+}
+
+teardown_virtualenv() {
+  rm -fr "${PYENV_ROOT}/versions/$1"
+}
+
+setup_pyvenv() {
+  create_executable "$1" "python"
+  create_executable "$1" "activate"
+  create_executable "$1" "pyvenv"
+  remove_executable "$1" "conda"
+}
+
+teardown_pyvenv() {
+  rm -fr "${PYENV_ROOT}/versions/$1"
+}
+
+setup_conda() {
+  create_executable "$1" "python"
+  create_executable "$1" "activate"
+  remove_executable "$1" "pyvenv"
+  create_executable "$1" "conda"
+  local conda="$1"
   shift 1
-  mkdir -p "${PYENV_ROOT}/versions/$version/bin"
-  touch "${PYENV_ROOT}/versions/$version/bin/activate"
-  touch "${PYENV_ROOT}/versions/$version/bin/conda"
-  touch "${PYENV_ROOT}/versions/$version/bin/python"
-  chmod +x "${PYENV_ROOT}/versions/$version/bin/conda"
-  chmod +x "${PYENV_ROOT}/versions/$version/bin/python"
-  local conda_env
-  for conda_env; do
-    mkdir -p "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin"
-    touch "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/activate"
-    touch "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/conda"
-    touch "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/python"
-    chmod +x "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/conda"
-    chmod +x "${PYENV_ROOT}/versions/$version/envs/$conda_env/bin/python"
+  local env
+  for env; do
+    create_executable "${conda}/envs/${env}" "python"
+    create_executable "${conda}/envs/${env}" "activate"
+    remove_executable "${conda}/envs/${env}" "pyvenv"
+    create_executable "${conda}/envs/${env}" "conda"
   done
+  
+}
+
+teardown_conda() {
+  rm -fr "${PYENV_ROOT}/versions/$1"
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -8,11 +8,9 @@ setup() {
 }
 
 @test "display virtualenv version" {
+  setup_virtualenv "2.7.7"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/2.7.7'"
   stub pyenv-exec "virtualenv --version : echo \"1.11\""
-
-  create_executable "2.7.7" "virtualenv"
-  remove_executable "2.7.7" "pyvenv"
 
   run pyenv-virtualenv --version
 
@@ -21,14 +19,13 @@ setup() {
 
   unstub pyenv-prefix
   unstub pyenv-exec
+  teardown_virtualenv "2.7.7"
 }
 
 @test "display pyvenv version" {
+  setup_pyvenv "3.4.1"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.4.1'"
   stub pyenv-which "pyvenv : echo \"${PYENV_ROOT}/versions/3.4.1/bin/pyvenv\""
-
-  remove_executable "3.4.1" "virtualenv"
-  create_executable "3.4.1" "pyvenv"
 
   run pyenv-virtualenv --version
 
@@ -36,4 +33,5 @@ setup() {
   assert_output "pyenv-virtualenv ${PYENV_VIRTUALENV_VERSION} (pyvenv 3.4.1)"
 
   unstub pyenv-prefix
+  teardown_pyvenv "3.4.1"
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -9,7 +9,6 @@ setup() {
 
 @test "display virtualenv version" {
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/2.7.7'"
-  stub pyenv-prefix "echo '${PYENV_ROOT}/versions/2.7.7'"
   stub pyenv-exec "virtualenv --version : echo \"1.11\""
 
   create_executable "2.7.7" "virtualenv"
@@ -25,7 +24,6 @@ setup() {
 }
 
 @test "display pyvenv version" {
-  stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.4.1'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/3.4.1'"
   stub pyenv-which "pyvenv : echo \"${PYENV_ROOT}/versions/3.4.1/bin/pyvenv\""
 

--- a/test/virtualenv.bats
+++ b/test/virtualenv.bats
@@ -7,11 +7,8 @@ setup() {
 }
 
 stub_pyenv() {
-  create_executable "${PYENV_VERSION}" "python"
+  setup_version "${PYENV_VERSION}"
   create_executable "${PYENV_VERSION}" "virtualenv"
-  remove_executable "${PYENV_VERSION}" "pyvenv"
-  remove_executable "${PYENV_VERSION}" "conda"
-
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-hooks "virtualenv : echo"
@@ -22,6 +19,7 @@ unstub_pyenv() {
   unstub pyenv-prefix
   unstub pyenv-hooks
   unstub pyenv-rehash
+  teardown_version "${PYENV_VERSION}"
 }
 
 @test "create virtualenv from given version" {

--- a/test/virtualenv.bats
+++ b/test/virtualenv.bats
@@ -7,11 +7,11 @@ setup() {
 }
 
 stub_pyenv() {
+  create_executable "${PYENV_VERSION}" "python"
   create_executable "${PYENV_VERSION}" "virtualenv"
   remove_executable "${PYENV_VERSION}" "pyvenv"
+  remove_executable "${PYENV_VERSION}" "conda"
 
-  stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
-  stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-prefix "echo '${PYENV_ROOT}/versions/${PYENV_VERSION}'"
   stub pyenv-hooks "virtualenv : echo"


### PR DESCRIPTION
With Anaconda/Miniconda version, `pyenv virtualenv` will automatically use `conda create` implicitly.