### PR TITLE
`pyenv virtualenvs` lists two entries for each virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,17 @@ $ pyenv virtualenv venv34
 `pyenv virtualenvs` shows you the list of existing virtualenvs and `conda` environments.
 
 ```sh
-$ pyenv shell venv27
+$ pyenv shell venv34
 $ pyenv virtualenvs
   miniconda3-3.9.1 (created from /home/yyuu/.pyenv/versions/miniconda3-3.9.1)
   miniconda3-3.9.1/envs/myenv (created from /home/yyuu/.pyenv/versions/miniconda3-3.9.1)
-* venv27 (created from /home/yyuu/.pyenv/versions/2.7.10)
-  venv34 (created from /home/yyuu/.pyenv/versions/3.4.3)
+  2.7.10/envs/my-virtual-env-2.7.10 (created from /home/yyuu/.pyenv/versions/2.7.10)
+  3.4.3/envs/venv34 (created from /home/yyuu/.pyenv/versions/3.4.3)
+  my-virtual-env-2.7.10 (created from /home/yyuu/.pyenv/versions/2.7.10)
+* venv34 (created from /home/yyuu/.pyenv/versions/3.4.3)
 ```
+
+There are two entries for each virtualenv, and the shorter one is just a symlink.
 
 
 ### Activate virtualenv


### PR DESCRIPTION
Issue described in #157. I changed the example of `pyenv virtualenvs`, listings twice the two virtualenvs created in the previous sections. 
Before this change, the output of `pyenv virtualenvs` listed only one entry per virtualenv. Furthermore, there was listed a virtualenv not previously created.