### PR TITLE
Hack to include nodeenv exports

### DIFF
--- a/bin/pyenv-sh-activate
+++ b/bin/pyenv-sh-activate
@@ -174,6 +174,7 @@ EOS
   cat <<EOS
 export PYENV_VIRTUAL_ENV="${prefix}";
 export VIRTUAL_ENV="${prefix}";
+source \$PYENV_VIRTUAL_ENV/bin/activate \$PYENV_VERSION;
 EOS
   ;;
 esac


### PR DESCRIPTION
Adds workarround for pyenv virtualenv not sourcing activate script which nodeenv -p appends its exports code to.

#162 