### PR TITLE
Do not display "deactivate" message with `--force` and `--quiet`

### DIFF
--- a/bin/pyenv-sh-deactivate
+++ b/bin/pyenv-sh-deactivate
@@ -58,7 +58,9 @@ else
   venv="${prefix##*/}"
 fi
 
-echo "pyenv-virtualenv: deactivate ${venv}" 1>&2
+if [ -n "${VIRTUAL_ENV}" ] || [ -z "${QUIET}" ]; then
+  echo "pyenv-virtualenv: deactivate ${venv}" 1>&2
+fi
 
 if [ -n "${PYENV_ACTIVATE_SHELL}" ]; then
   # shell version set in pyenv-sh-activate should be unset


### PR DESCRIPTION
This is used by `pyenv activate` and is unnecessarily noisy (and
confusing).

This seems to be sensible regardless of having an "activate" message
with or without `--verbose`
(see https://github.com/yyuu/pyenv-virtualenv/pull/169).

TODO
 - [ ] test(s) in case this is accepted