### PR TITLE
Use `source` in favor of `.` (fixes #175)

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -71,7 +71,7 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and . (pyenv virtualenv-init -|psub)'
+      echo 'status --is-interactive; and source (pyenv virtualenv-init -|psub)'
       ;;
     * )
       echo 'eval "$(pyenv virtualenv-init -)"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -42,7 +42,7 @@ load test_helper
 @test "fish instructions" {
   run pyenv-virtualenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_output_contains 'status --is-interactive; and . (pyenv virtualenv-init -|psub)'
+  assert_output_contains 'status --is-interactive; and source (pyenv virtualenv-init -|psub)'
 }
 
 @test "outputs bash-specific syntax" {


### PR DESCRIPTION
* https://github.com/yyuu/pyenv/pull/615
* https://github.com/fish-shell/fish-shell/issues/310