### PR TITLE
Create relative symlink

### DIFF
--- a/bin/pyenv-virtualenv
+++ b/bin/pyenv-virtualenv
@@ -583,7 +583,7 @@ fi
 
 ## Create symlink in the `versions` directory for backward compatibility
 if [ -d "${VIRTUALENV_PATH}" ] && [ -n "${COMPAT_VIRTUALENV_PATH}" ]; then
-  ln -fs "${VIRTUALENV_PATH}" "${COMPAT_VIRTUALENV_PATH}"
+  ln -rfs "${VIRTUALENV_PATH}" "${COMPAT_VIRTUALENV_PATH}"
 fi
 
 if [ ! -e "${VIRTUALENV_PATH}/bin/pydoc" ]; then


### PR DESCRIPTION
In my use case I sometimes move around the whole pyenv directory and this absolute link breaks my setup.
I don't see many (any?) disadvantages in always creating this symlink as a relative link.

Any other opinions?