### PR TITLE
Make the fish prompt faster

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -107,9 +107,12 @@ fish )
 function _pyenv_virtualenv_hook --on-variable PWD --on-variable PYENV_VERSION;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
-    pyenv activate --quiet; or pyenv deactivate --quiet; or true
+    function _pyenv_activate_or_deactivate
+      pyenv activate --quiet || pyenv deactivate --quiet
+    end
+    _pyenv_activate_or_deactivate &
   else
-    pyenv activate --quiet; or true
+    pyenv activate --quiet &
   end
   return \$ret
 end

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -104,7 +104,7 @@ esac
 case "$shell" in
 fish )
   cat <<EOS
-function _pyenv_virtualenv_hook --on-event fish_prompt;
+function _pyenv_virtualenv_hook --on-variable PWD --on-variable PYENV_VERSION;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
     pyenv activate --quiet; or pyenv deactivate --quiet; or true
@@ -113,6 +113,7 @@ function _pyenv_virtualenv_hook --on-event fish_prompt;
   end
   return \$ret
 end
+_pyenv_virtualenv_hook
 EOS
  ;;
 ksh )

--- a/test/init.bats
+++ b/test/init.bats
@@ -76,15 +76,19 @@ while set index (contains -i -- "${TMP}/pyenv/plugins/pyenv-virtualenv/shims" \$
 set -eg PATH[\$index]; end; set -e index
 set -gx PATH '${TMP}/pyenv/plugins/pyenv-virtualenv/shims' \$PATH;
 set -gx PYENV_VIRTUALENV_INIT 1;
-function _pyenv_virtualenv_hook --on-event fish_prompt;
+function _pyenv_virtualenv_hook --on-variable PWD --on-variable PYENV_VERSION;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
-    pyenv activate --quiet; or pyenv deactivate --quiet; or true
+    function _pyenv_activate_or_deactivate
+      pyenv activate --quiet || pyenv deactivate --quiet
+    end
+    _pyenv_activate_or_deactivate &
   else
-    pyenv activate --quiet; or true
+    pyenv activate --quiet &
   end
   return \$ret
 end
+_pyenv_virtualenv_hook
 EOS
 }
 


### PR DESCRIPTION
This speeds it up using two methods:
- Run the hook `_pyenv_virtualenv_hook` only when `$PWD` or `$PYENV_VERSION` change. This was taken from https://github.com/pyenv/pyenv-virtualenv/issues/338#issuecomment-1366158648. Note that this doesn't automatically work when you open a shell in a directory, so this is manually called during shell init.
- Inside the hook, run the pyenv (de)activation in the background. Thus, this doesn't block the rest of the shell.

This fixes #338.