### PR TITLE
Fix zsh shell hook performance issue

### DIFF
--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -104,7 +104,7 @@ esac
 case "$shell" in
 fish )
   cat <<EOS
-function _pyenv_virtualenv_hook --on-variable PWD;
+function _pyenv_virtualenv_hook --on-event fish_prompt;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
     pyenv activate --quiet; or pyenv deactivate --quiet; or true

--- a/bin/pyenv-virtualenv-init
+++ b/bin/pyenv-virtualenv-init
@@ -104,7 +104,7 @@ esac
 case "$shell" in
 fish )
   cat <<EOS
-function _pyenv_virtualenv_hook --on-event fish_prompt;
+function _pyenv_virtualenv_hook --on-variable PWD;
   set -l ret \$status
   if [ -n "\$VIRTUAL_ENV" ]
     pyenv activate --quiet; or pyenv deactivate --quiet; or true
@@ -149,9 +149,9 @@ EOS
     ;;
   zsh )
     cat <<EOS
-typeset -g -a precmd_functions
-if [[ -z \$precmd_functions[(r)_pyenv_virtualenv_hook] ]]; then
-  precmd_functions=(_pyenv_virtualenv_hook \$precmd_functions);
+typeset -g -a precwd_functions
+if [[ -z \$precwd_functions[(r)_pyenv_virtualenv_hook] ]]; then
+  precwd_functions=(_pyenv_virtualenv_hook \$precwd_functions);
 fi
 EOS
     ;;


### PR DESCRIPTION
The precmd hook is causing a significant overhead on every command executed in the shell.
The shell hook does not need to be this strict however, it can also run only on directory changes, ensuring that the shell remains snappy while executing commands.

Also contains a similar fix for fish.

Fixes #259.